### PR TITLE
Integrate Marathon BIG-IP Controller to use CCCL and CCCL Schema

### DIFF
--- a/build-tools/Dockerfile.runtime
+++ b/build-tools/Dockerfile.runtime
@@ -10,6 +10,7 @@ WORKDIR $APPPATH
 
 COPY marathon-runtime-requirements.txt /tmp/runtime-requirements.txt
 COPY run $APPPATH
+COPY common.py $APPPATH
 COPY marathon-bigip-ctlr.py $APPPATH
     
 RUN apk --no-cache --update add --virtual pip-install-deps git && \

--- a/build-tools/build-runtime-images.sh
+++ b/build-tools/build-runtime-images.sh
@@ -11,6 +11,7 @@ WKDIR=$(mktemp -d docker-build.XXXX)
 cp $CURDIR/Dockerfile.runtime $WKDIR
 cp $CURDIR/../marathon-runtime-requirements.txt $WKDIR
 cp $CURDIR/../marathon-bigip-ctlr.py $WKDIR
+cp $CURDIR/../common.py $WKDIR
 cp $CURDIR/../run $WKDIR
 
 echo "Docker build context:"

--- a/build-tools/lint.sh
+++ b/build-tools/lint.sh
@@ -21,7 +21,7 @@ broad-except"
 
 [ -z $1 ] ||  DEFAULTS=$@
 
-LIST="$(find . -name '*py' ! -path '*test*' ! -path '*docs*' ! -path '*f5_cccl*' )"
+LIST="$(find . -name '*py' ! -path '*test*' ! -path '*docs*' ! -path '*f5-cccl*' )"
 for i in $LIST; do
     pylint $i $DEFAULTS
 done

--- a/common.py
+++ b/common.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+#
+# Copyright 2017 F5 Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common utility functions."""
+
+import sys
+import time
+import json
+import logging
+import socket
+import argparse
+
+import jwt
+import requests
+
+from requests.auth import AuthBase
+
+
+def parse_log_level(log_level_arg):
+    """Parse the log level from the args.
+
+    Args:
+        log_level_arg: String representation of log level
+    """
+    LOG_LEVELS = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']
+    if log_level_arg not in LOG_LEVELS:
+        msg = 'Invalid option: {0} (Valid choices are {1})'.format(
+            log_level_arg, LOG_LEVELS)
+        raise argparse.ArgumentTypeError(msg)
+
+    log_level = getattr(logging, log_level_arg, logging.INFO)
+
+    return log_level
+
+
+def setup_logging(logger, log_format, log_level):
+    """Configure logging."""
+    logger.setLevel(log_level)
+
+    formatter = logging.Formatter(log_format)
+
+    consoleHandler = logging.StreamHandler(sys.stdout)
+    consoleHandler.setFormatter(formatter)
+    logger.addHandler(consoleHandler)
+    logger.propagate = False
+
+
+def set_marathon_auth_args(parser):
+    """Set the authorization for Marathon."""
+    parser.add_argument("--marathon-auth-credential-file",
+                        env_var='F5_CC_MARATHON_AUTH',
+                        help="Path to file containing a user/pass for "
+                        "the Marathon HTTP API in the format of 'user:pass'.")
+    parser.add_argument("--dcos-auth-credentials",
+                        env_var='F5_CC_DCOS_AUTH_CREDENTIALS',
+                        help="DC/OS service account credentials")
+    parser.add_argument("--dcos-auth-token",
+                        env_var='F5_CC_DCOS_AUTH_TOKEN',
+                        help="DC/OS ACS Token")
+
+    return parser
+
+
+class DCOSAuth(AuthBase):
+    """DCOSAuth class.
+
+    Manage authorization credentials for DCOS
+    """
+
+    def __init__(self, credentials, ca_cert, token):
+        """Initialize DCOSAuth."""
+        if credentials:
+            creds = json.loads(credentials)
+            self.scheme = creds['scheme']
+            self.uid = creds['uid']
+            self.private_key = creds['private_key']
+            self.login_endpoint = creds['login_endpoint']
+        self.token = token
+        self.verify = False
+        self.auth_header = None
+        self.expiry = 0
+        if ca_cert:
+            self.verify = ca_cert
+
+    def __call__(self, auth_request):
+        """Get the ACS token."""
+        if self.token:
+            self.auth_header = 'token=' + self.token
+            auth_request.headers['Authorization'] = self.auth_header
+            return auth_request
+
+        if not self.auth_header or int(time.time()) >= self.expiry - 10:
+            self.expiry = int(time.time()) + 3600
+            payload = {
+                'uid': self.uid,
+                # This is the expiry of the auth request params
+                'exp': int(time.time()) + 60,
+            }
+            token = jwt.encode(payload, self.private_key, self.scheme)
+
+            data = {
+                'uid': self.uid,
+                'token': token.decode('ascii'),
+                # This is the expiry for the token itself
+                'exp': self.expiry,
+            }
+            r = requests.post(self.login_endpoint,
+                              json=data,
+                              timeout=(3.05, 46),
+                              verify=self.verify)
+            r.raise_for_status()
+
+            self.auth_header = 'token=' + r.cookies['dcos-acs-auth-cookie']
+
+        auth_request.headers['Authorization'] = self.auth_header
+        return auth_request
+
+
+def get_marathon_auth_params(args):
+    """Get the Marathon credentials."""
+    marathon_auth = None
+    if args.marathon_auth_credential_file:
+        with open(args.marathon_auth_credential_file, 'r') as f:
+            line = f.readline().rstrip('\r\n')
+
+        if line:
+            marathon_auth = tuple(line.split(':'))
+    elif args.dcos_auth_credentials or args.dcos_auth_token:
+        return DCOSAuth(args.dcos_auth_credentials, args.marathon_ca_cert,
+                        args.dcos_auth_token)
+
+    if marathon_auth and len(marathon_auth) != 2:
+        print(
+            "Please provide marathon credentials in user:pass format"
+        )
+        sys.exit(1)
+
+    return marathon_auth
+
+
+def set_logging_args(parser):
+    """Add logging-related args to the parser."""
+    parser.add_argument("--log-format",
+                        env_var='F5_CC_LOG_FORMAT',
+                        help="Set log message format",
+                        default="%(asctime)s %(name)s: %(levelname)"
+                        " -8s: %(message)s")
+    parser.add_argument("--log-level",
+                        env_var='F5_CC_LOG_LEVEL',
+                        type=parse_log_level,
+                        help="Set logging level. Valid log levels are: "
+                        "DEBUG, INFO, WARNING, ERROR, and CRITICAL",
+                        default='INFO')
+    return parser
+
+
+ip_cache = dict()
+
+
+def resolve_ip(host):
+    """Get the IP address for a hostname."""
+    cached_ip = ip_cache.get(host, None)
+    if cached_ip:
+        return cached_ip
+    else:
+        try:
+            ip = socket.gethostbyname(host)
+            ip_cache[host] = ip
+            return ip
+        except socket.gaierror:
+            return None

--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -32,6 +32,7 @@ marathon-bigip-ctlr just needs to know where to find Marathon.
 
 from __future__ import print_function
 
+import ipaddress
 import json
 import logging
 from operator import attrgetter
@@ -49,11 +50,35 @@ import requests
 from requests.exceptions import ConnectionError
 from sseclient import SSEClient
 
-from f5_cccl.common import (set_logging_args, set_marathon_auth_args,
-                            setup_logging, get_marathon_auth_params,
-                            resolve_ip)
-from f5_cccl._f5 import (CloudBigIP, has_partition,
-                         healthcheck_timeout_calculate, get_protocol)
+from common import (set_logging_args, set_marathon_auth_args,
+                    setup_logging, get_marathon_auth_params, resolve_ip)
+from f5.bigip import ManagementRoot
+from f5_cccl.api import F5CloudServiceManager
+from f5_cccl.exceptions import F5CcclError
+
+
+# BIG-IP load-balancing methods
+lb_methods = [
+    "dynamic-ratio-member",
+    "dynamic-ratio-node",
+    "fastest-app-response",
+    "fastest-node",
+    "least-connections-member",
+    "least-connections-node",
+    "least-sessions",
+    "observed-member",
+    "observed-node",
+    "predictive-member",
+    "predictive-node",
+    "ratio-least-connections-member",
+    "ratio-least-connections-node",
+    "ratio-member",
+    "ratio-node",
+    "round-robin",
+    "ratio-session",
+    "weighted-least-connections-member",
+    "weighted-least-connections-node"
+]
 
 
 class InvalidServiceDefinitionError(ValueError):
@@ -65,7 +90,6 @@ class InvalidServiceDefinitionError(ValueError):
     be defined.
     A helpful error is logged to the user at loglevel warning.
     """
-
 
 # Setter function callbacks that correspond to specific labels: they will
 # handle validating the value (v) and setting attributes on the object (x).
@@ -261,6 +285,91 @@ prefix_label_keys = {
 
 
 logger = logging.getLogger('controller')
+
+
+def healthcheck_timeout_calculate(data):
+    """Calculate a BIG-IP Health Monitor timeout.
+
+    Args:
+        data: BIG-IP config dict
+    """
+    # Calculate timeout
+    # See the f5 monitor docs for explanation of settings:
+    # https://goo.gl/JJWUIg
+    # Formula to match up the cloud settings with f5 settings:
+    # (( maxConsecutiveFailures - 1) * intervalSeconds )
+    # + timeoutSeconds + 1
+    timeout = (
+        ((data['maxConsecutiveFailures'] - 1) * data['intervalSeconds']) +
+        data['timeoutSeconds'] + 1
+    )
+    return timeout
+
+
+def get_protocol(protocol):
+    """Return the protocol (tcp or udp).
+
+    This converts from the marathon protocol (udp, tcp, or http) to the BIG-IP
+    protocol (udp or tcp); http is handled at a different layer on top of tcp
+    in BIG-IP config
+    """
+    if str(protocol).lower() == 'tcp':
+        return 'tcp'
+    if str(protocol).lower() == 'http':
+        return 'tcp'
+    if str(protocol).lower() == 'udp':
+        return 'udp'
+    return None
+
+
+def is_label_data_valid(app):
+    """Validate the Marathon app's label data.
+
+    Args:
+        app: The app to be validated
+    """
+    is_valid = True
+    msg = 'Application label {0} for {1} contains an invalid value: {2}'
+
+    # Validate mode
+    if get_protocol(app.mode) is None:
+        logger.error(msg.format('F5_MODE', app.appId, app.mode))
+        is_valid = False
+
+    # Validate port
+    if app.servicePort < 1 or app.servicePort > 65535:
+        logger.error(msg.format('F5_PORT', app.appId, app.servicePort))
+        is_valid = False
+
+    # Validate address
+    if app.bindAddr is not None:
+        try:
+            ipaddress.ip_address(app.bindAddr)
+        except ValueError:
+            logger.error(msg.format('F5_BIND_ADDR', app.appId, app.bindAddr))
+            is_valid = False
+
+    # Validate load-balancing method
+    if app.balance is not None and app.balance not in lb_methods:
+        logger.error(msg.format('F5_BALANCE', app.appId, app.balance))
+        is_valid = False
+
+    return is_valid
+
+
+def healthcheck_sendstring(data):
+    """Return the 'send' string for a health monitor.
+
+    Args:
+        data: Health Monitor dict
+    """
+    if data['protocol'] == "http":
+        send_string = 'GET / HTTP/1.0\\r\\n\\r\\n'
+        if 'path' in data:
+            send_string = 'GET %s HTTP/1.0\\r\\n\\r\\n' % data['path']
+        return send_string
+    else:
+        return None
 
 
 class MarathonBackend(object):
@@ -552,7 +661,85 @@ def get_apps(apps, health_check):
     return apps_list
 
 
-def create_config_marathon(bigip, apps):
+def iapp_build_definition(config, members):
+    """Create a dict that defines the 'variables' and 'tables' for an iApp.
+
+    Args:
+        config: BIG-IP config dict
+    """
+    # Build variable list
+    variables = []
+    for key, value in config['variables'].items():
+        var = {'name': key, 'value': value}
+        variables.append(var)
+
+    # The schema says only one of poolMemberTable or tableName is
+    # valid, so if the user set both it should have already been rejected.
+    # But if not, prefer the new poolMemberTable over tableName.
+    tables = []
+    if 'poolMemberTable' in config:
+        tableConfig = config['poolMemberTable']
+
+        # Construct columnNames array from the 'name' prop of each column
+        columnNames = []
+        for col in tableConfig['columns']:
+            columnNames.append(col['name'])
+
+        # Construct rows array - one row for each node, interpret the
+        # 'kind' or 'value' from the column spec.
+        rows = []
+        for node in members:
+            row = []
+            for i, col in enumerate(tableConfig['columns']):
+                if 'value' in col:
+                    row.append(col['value'])
+                elif 'kind' in col:
+                    if col['kind'] == 'IPAddress':
+                        row.append(str(node['address']))
+                    elif col['kind'] == 'Port':
+                        row.append(str(node['port']))
+                    else:
+                        raise ValueError('Unknown kind "%s"' % col['kind'])
+                else:
+                    raise ValueError('Column %d has neither value nor kind'
+                                     % i)
+            rows.append({'row': row})
+
+        # Done - add the generated pool member table to the set of tables
+        # we're going to configure.
+        tables.append({
+            'name': tableConfig['name'],
+            'columnNames': columnNames,
+            'rows': rows
+        })
+    elif 'tableName' in config:
+        # Before adding the flexible poolMemberTable mode, we only
+        # supported three fixed columns in order, and connection_limit was
+        # hardcoded to 0 ("no limit")
+        rows = []
+        for node in members:
+            rows.append({'row': [str(node['address']),
+                                 str(node['port']), '0']})
+        tables.append({
+            'name': config['tableName'],
+            'columnNames': ['addr', 'port', 'connection_limit'],
+            'rows': rows
+        })
+
+    # Add other tables
+    for key in config['tables']:
+        data = config['tables'][key]
+        table = {'columnNames': data['columns'],
+                 'name': key,
+                 'rows': []}
+        for row in data['rows']:
+            table['rows'].append({'row': row})
+        tables.append(table)
+
+    return {'variables': variables, 'tables': tables}
+
+
+def create_config_marathon(cccl, apps):
     """Create a BIG-IP configuration from the Marathon app list.
 
     Args:
@@ -563,33 +750,27 @@ def create_config_marathon(bigip, apps):
         logger.debug(app.__hash__())
 
     logger.info("Generating config for BIG-IP")
-    f5 = {}
-    # partitions this script is responsible for:
-    partitions = frozenset(bigip.get_partitions())
+    services = {
+        'virtualServers': [],
+        'l7Policies': [],
+        'pools': [],
+        'monitors': [],
+        'iapps': []
+    }
 
-    for app in sorted(apps, key=attrgetter('appId', 'servicePort')):
-        f5_service = {
-            'nodes': {},
-            'partition': '',
-            'name': ''
-        }
+    for app in apps:
         # Only handle application if it's partition is one that this script
         # is responsible for
-        if not has_partition(partitions, app.partition):
+        if cccl.get_partition() != app.partition:
             continue
 
-        # No address or iApp for this port
-        if not app.bindAddr and not app.iapp:
-            # Validate pool only configuration
-            if not bigip.is_label_data_valid(app):
-                continue
-            else:
-                logger.debug("Creating pool only for %s", app.appId)
         # Validate data from the app's labels
-        elif not app.iapp and not bigip.is_label_data_valid(app):
+        if not app.iapp and not is_label_data_valid(app):
             continue
 
-        f5_service['partition'] = app.partition
+        # No address or iApp for this port (pool-only config)
+        if not app.bindAddr and not app.iapp:
+            logger.debug("Creating pool only for %s", app.appId)
 
         logger.info("Configuring app %s, partition %s", app.appId,
                     app.partition)
@@ -600,20 +781,37 @@ def create_config_marathon(bigip, apps):
         # The Marathon appId contains the full path, replace all '/' in
         # the name with '_'
         frontend_name = frontend_name.replace('/', '_')
-        f5_service['name'] = frontend_name
+
         if app.bindAddr:
             logger.debug("Frontend at %s:%d with backend %s", app.bindAddr,
                          app.servicePort, backend)
 
+        # pool members
+        members = []
+        key_func = attrgetter('host', 'port')
+        for backendServer in sorted(app.backends, key=key_func):
+            logger.debug("Found backend server at %s:%d for app %s",
+                         backendServer.host, backendServer.port, app.appId)
+
+            # Resolve backendServer hostname to IP address
+            ip = resolve_ip(backendServer.host)
+
+            if ip is not None:
+                member = {
+                    'address': ip,
+                    'port': backendServer.port,
+                    'session': 'user-enabled'
+                }
+                members.append(member)
+            else:
+                logger.warning("Could not resolve ip for host %s, "
+                               "ignoring this backend", backendServer.host)
+
         if app.iapp:
             # Translate from the internal properties we set on app to the
-            # naming expected by the common f5_service['iapp']
+            # naming expected by the iapp.
             # Only set properties that are actually present.
-            #
-            # tableName would be better as poolMemberTableName but it is
-            # required to be tableName to match the tableName produced by
-            # the k8s-bigip-ctlr
-            f5_service['iapp'] = {}
+            cfg = {}
             for k, v in {'template': 'iapp',
                          'tableName': 'iappPoolMemberTableName',
                          'poolMemberTable': 'iappPoolMemberTable',
@@ -621,32 +819,58 @@ def create_config_marathon(bigip, apps):
                          'variables': 'iappVariables',
                          'options': 'iappOptions'}.iteritems():
                 if hasattr(app, v):
-                    f5_service['iapp'][k] = getattr(app, v)
+                    cfg[k] = getattr(app, v)
 
-            # Decode the tables
-            for key in app.iappTables:
-                f5_service['iapp']['tables'][key] = \
-                    json.loads(app.iappTables[key])
+            try:
+                # Decode the tables
+                for key in app.iappTables:
+                    cfg['tables'][key] = json.loads(app.iappTables[key])
+            except ValueError:
+                logger.error("IAPP TABLE data is not valid JSON")
+                continue
+
+            try:
+                # format the variables and tables per the schema
+                iapp_def = iapp_build_definition(cfg, members)
+            except ValueError as e:
+                logger.error("Invalid pool-member table data: %s", e)
+                continue
+
+            iapp = {
+                'name': frontend_name,
+                'template': cfg['template'],
+                'variables': iapp_def['variables'],
+                'tables': iapp_def['tables'],
+                'options': cfg['options']
+            }
+
+            services['iapps'].append(iapp)
         else:
-            f5_service['virtual'] = {}
-            f5_service['pool'] = {}
-            f5_service['health'] = []
-
+            monitors = []
             if app.healthCheck:
-                for hc in app.healthCheck:
+                for counter, hc in enumerate(app.healthCheck):
                     logger.debug("Healthcheck for app '%s': %s",
                                  app.appId, hc)
-                    hc['name'] = frontend_name
 
-                    # normalize healtcheck protocol name to lowercase
+                    # normalize healthcheck protocol name to lowercase
                     if 'protocol' in hc:
-                        hc['protocol'] = (hc['protocol']).lower()
+                        hc['type'] = (hc['protocol']).lower()
                     hc.update({
                         'interval': hc['intervalSeconds'],
-                        'timeout': healthcheck_timeout_calculate(hc),
-                        'send': bigip.healthcheck_sendstring(hc),
+                        'timeout': healthcheck_timeout_calculate(hc)
                     })
-                    f5_service['health'].append(hc)
+
+                    # Append the index and protocol to the monitor name to
+                    # keep them unique
+                    hc['name'] = frontend_name + '_' + str(counter) + '_' + \
+                        hc['type']
+
+                    send = healthcheck_sendstring(hc)
+                    if send is not None:
+                        hc['send'] = send
+                    monitors.append(hc)
+
+                services['monitors'] += monitors
 
             # Parse the SSL profile into partition and name
             profiles = []
@@ -661,16 +885,18 @@ def create_config_marathon(bigip, apps):
 
             # Add appropriate profiles
             if str(app.mode).lower() == 'http':
+                # BIG-IP will automatically add the tcp profile for http
+                # because it is an inherited profile. Explictly add the tcp
+                # profile so that we don't fail comparison matches later.
                 profiles.append({'partition': 'Common', 'name': 'http'})
+                profiles.append({'partition': 'Common', 'name': 'tcp'})
             elif get_protocol(app.mode) == 'tcp':
                 profiles.append({'partition': 'Common', 'name': 'tcp'})
 
             if app.bindAddr:
-                f5_service['virtual_address'] = app.bindAddr
-
-                f5_service['virtual'].update({
+                virtual = {
+                    'name': frontend_name,
                     'enabled': True,
-                    'disabled': False,
                     'ipProtocol': get_protocol(app.mode),
                     'destination':
                     "/%s/%s:%d" % (app.partition, app.bindAddr,
@@ -678,37 +904,21 @@ def create_config_marathon(bigip, apps):
                     'pool': "/%s/%s" % (app.partition, frontend_name),
                     'sourceAddressTranslation': {'type': 'automap'},
                     'profiles': profiles
-                })
-            f5_service['pool'].update({
-                'monitor': "/%s/%s" %
-                           (app.partition, f5_service['health'][0]['name'])
-                           if app.healthCheck else None,
-                'loadBalancingMode': app.balance
-            })
+                }
+                services['virtualServers'].append(virtual)
 
-        key_func = attrgetter('host', 'port')
-        for backendServer in sorted(app.backends, key=key_func):
-            logger.debug("Found backend server at %s:%d for app %s",
-                         backendServer.host, backendServer.port, app.appId)
+            pool = {
+                'name': frontend_name,
+                'monitors': ["/%s/%s" %
+                             (app.partition, m['name']) for m in monitors],
+                'loadBalancingMode': app.balance,
+                'members': members
+            }
+            services['pools'].append(pool)
 
-            # Resolve backendServer hostname to IP address
-            ipv4 = resolve_ip(backendServer.host)
+    logger.debug("Service Config: %s", json.dumps(services))
 
-            if ipv4 is not None:
-                f5_node_name = ipv4 + ':' + str(backendServer.port)
-                f5_service['nodes'].update({f5_node_name: {
-                    'state': 'user-up',
-                    'session': 'user-enabled'
-                }})
-            else:
-                logger.warning("Could not resolve ip for host %s, "
-                               "ignoring this backend", backendServer.host)
-
-        f5.update({frontend_name: f5_service})
-
-    logger.debug("F5 json config: %s", json.dumps(f5))
-
-    return f5
+    return services
 
 
 class MarathonEventProcessor(object):
@@ -718,7 +928,7 @@ class MarathonEventProcessor(object):
     reconfigures the BIG-IP
     """
 
-    def __init__(self, marathon, verify_interval, bigip):
+    def __init__(self, marathon, verify_interval, cccls):
         """Class init.
 
         Starts a thread that waits for Marathon events,
@@ -727,7 +937,7 @@ class MarathonEventProcessor(object):
         self.__marathon = marathon
         # appId -> MarathonApp
         self.__apps = dict()
-        self.__bigip = bigip
+        self.__cccls = cccls
         self.__verify_interval = verify_interval
 
         self.__condition = threading.Condition()
@@ -745,7 +955,7 @@ class MarathonEventProcessor(object):
     def do_reset(self):
         """Process the Marathon state and reconfigure the BIG-IP."""
         with self.__condition:
-            while True:
+            while True:  # pylint: disable=too-many-nested-blocks
                 self.__condition.acquire()
                 if not self.__pending_reset:
                     self.__condition.wait()
@@ -759,11 +969,21 @@ class MarathonEventProcessor(object):
                         self.__timer.cancel()
                         self.__timer = None
 
-                    self.__apps = get_apps(self.__marathon.list(),
-                                           self.__marathon.health_check())
-                    cfg = create_config_marathon(self.__bigip, self.__apps)
-                    if self.__bigip.regenerate_config_f5(cfg):
-                        # Timeout (or some other retryable error occurred),
+                    self.__apps = \
+                        sorted(get_apps(self.__marathon.list(),
+                                        self.__marathon.health_check()),
+                               key=attrgetter('appId', 'servicePort'))
+
+                    incomplete = 0
+                    for cccl in self.__cccls:
+                        cfg = create_config_marathon(cccl, self.__apps)
+                        try:
+                            incomplete += cccl.apply_config(cfg)
+                        except F5CcclError as e:
+                            logger.error("CCCL Error: %s", e.msg)
+
+                    if incomplete:
+                        # Some retryable error occurred),
                         # do a reset so that we try again
                         self.retry_backoff(self.reset_from_tasks)
                     else:
@@ -771,22 +991,23 @@ class MarathonEventProcessor(object):
                         self.start_checkpoint_timer()
                         self._backoff_timer = 1
 
-                        perf_enable = os.environ.get('SCALE_PERF_ENABLE')
-                        if perf_enable:  # pragma: no cover
-                            test_data = {}
-                            app_count = 0
-                            backend_count = 0
-                            for app in self.__apps:
-                                if app.partition == 'test':
-                                    app_count += 1
-                                    backends = len(app.backends)
-                                    test_data[app.appId[1:]] = backends
-                                    backend_count += backends
-                            test_data['Total_Services'] = app_count
-                            test_data['Total_Backends'] = backend_count
-                            test_data['Time'] = time.time()
-                            json_data = json.dumps(test_data)
-                            logger.info('SCALE_PERF: Test data: %s', json_data)
+                    perf_enable = os.environ.get('SCALE_PERF_ENABLE')
+                    if perf_enable:  # pragma: no cover
+                        test_data = {}
+                        app_count = 0
+                        backend_count = 0
+                        for app in self.__apps:
+                            if app.partition == 'test':
+                                app_count += 1
+                                backends = len(app.backends)
+                                test_data[app.appId[1:]] = backends
+                                backend_count += backends
+                        test_data['Total_Services'] = app_count
+                        test_data['Total_Backends'] = backend_count
+                        test_data['Time'] = time.time()
+                        json_data = json.dumps(test_data)
+                        logger.info('SCALE_PERF: Test data: %s',
+                                    json_data)
 
                     logger.debug("updating tasks finished, took %s seconds",
                                  time.time() - start_time)
@@ -860,8 +1081,8 @@ def get_arg_parser():
     parser.add_argument("--partition",
                         env_var='F5_CC_PARTITIONS',
                         help="[required] Only generate config for apps which"
-                        " match the specified partition. Use '*' to match all"
-                        " partitions.  Can use this arg multiple times to"
+                        " match the specified partition."
+                        " Can use this arg multiple times to"
                         " specify multiple partitions",
                         action="append",
                         default=list())
@@ -887,7 +1108,7 @@ def get_arg_parser():
     return parser
 
 
-def process_sse_events(processor, events, bigip):
+def process_sse_events(processor, events):
     """Process Server Side Events (SSE) from Marathon."""
     for event in events:
         try:
@@ -968,16 +1189,31 @@ if __name__ == '__main__':
     # parse args
     args = parse_args()
 
-    bigip = CloudBigIP(args.host, args.port, args.username,
-                       args.password, args.partition, token="tmos")
+    # Setup logging
+    setup_logging(logging.getLogger(), args.log_format, args.log_level)
+
+    # BIG-IP to manage
+    bigip = ManagementRoot(
+        args.host,
+        args.username,
+        args.password,
+        port=args.port,
+        token="tmos")
+
+    # Management for the BIG-IP partitions
+    cccls = []
+    for partition in args.partition:
+        cccl = F5CloudServiceManager(
+            bigip,
+            partition,
+            prefix="",
+            schema_path="./src/f5-cccl/f5_cccl/schemas/cccl-api-schema.yml")
+        cccls.append(cccl)
 
     # Set request retries
     s = requests.Session()
     a = requests.adapters.HTTPAdapter(max_retries=3)
     s.mount('http://', a)
-
-    # Setup logging
-    setup_logging(logger, args.log_format, args.log_level)
 
     if os.environ.get('SCALE_PERF_ENABLE'):
         logger.info('SCALE_PERF: Started controller at: %f', time.time())
@@ -988,12 +1224,11 @@ if __name__ == '__main__':
                         get_marathon_auth_params(args),
                         args.marathon_ca_cert)
 
-    processor = MarathonEventProcessor(marathon, args.verify_interval,
-                                       bigip)
+    processor = MarathonEventProcessor(marathon, args.verify_interval, cccls)
     while True:
         try:
             events = marathon.get_event_stream(args.sse_timeout)
-            process_sse_events(processor, events, bigip)
+            process_sse_events(processor, events)
         except Exception:
             logger.exception("Marathon event exception:")
             logger.error("Reconnecting to Marathon event stream...")

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@24eb8eb87c8bb313826f7598a8ca6b338169679a#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@83d7a311767ea8ca47e144233c4697fce0a3a2bd#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@24eb8eb87c8bb313826f7598a8ca6b338169679a#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@83d7a311767ea8ca47e144233c4697fce0a3a2bd#egg=f5-cccl
 f5-icontrol-rest==1.3.0
 f5-sdk==2.2.2
 requests==2.9.1

--- a/tests/marathon_app_no_hm_expected.json
+++ b/tests/marathon_app_no_hm_expected.json
@@ -1,0 +1,136 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31132,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31615,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_80_0_http"
+            ],
+            "name": "server-app_80"
+        },
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31356,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31627,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [],
+            "name": "server-app3_8089"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_80",
+            "pool": "/mesos/server-app_80",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        },
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:8089",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app3_8089",
+            "pool": "/mesos/server-app3_8089",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_app_with_one_unconfig_service_port_expected.json
+++ b/tests/marathon_app_with_one_unconfig_service_port_expected.json
@@ -1,0 +1,175 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app4_8080_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        },
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app4_8090_0_http",
+            "path": "/",
+            "portIndex": 1,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        },
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app4_10003_0_http",
+            "path": "/",
+            "portIndex": 2,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31365,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31388,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app4_8080_0_http"
+            ],
+            "name": "server-app4_8080"
+        },
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31366,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31389,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app4_8090_0_http"
+            ],
+            "name": "server-app4_8090"
+        },
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31367,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31390,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app4_10003_0_http"
+            ],
+            "name": "server-app4_10003"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:8080",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app4_8080",
+            "pool": "/mesos/server-app4_8080",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        },
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.242:8090",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app4_8090",
+            "pool": "/mesos/server-app4_8090",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_invalid_apps_expected.json
+++ b/tests/marathon_invalid_apps_expected.json
@@ -1,0 +1,72 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31132,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31615,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_80_0_http"
+            ],
+            "name": "server-app_80"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "udp",
+            "name": "server-app_80",
+            "pool": "/mesos/server-app_80",
+            "profiles": [],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_no_apps_expected.json
+++ b/tests/marathon_no_apps_expected.json
@@ -1,0 +1,7 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [],
+    "pools": [],
+    "virtualServers": []
+}

--- a/tests/marathon_one_app_https_expected.json
+++ b/tests/marathon_one_app_https_expected.json
@@ -1,0 +1,94 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31132,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31615,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_80_0_http"
+            ],
+            "name": "server-app_80"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_80",
+            "pool": "/mesos/server-app_80",
+            "profiles": [
+                {
+                    "name": "clientssl",
+                    "partition": "Common"
+                },
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_one_app_in_subdir_expected.json
+++ b/tests/marathon_one_app_in_subdir_expected.json
@@ -1,0 +1,90 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "my_services_test-2_server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31132,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31615,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/my_services_test-2_server-app_80_0_http"
+            ],
+            "name": "my_services_test-2_server-app_80"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "my_services_test-2_server-app_80",
+            "pool": "/mesos/my_services_test-2_server-app_80",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_one_app_missing_data_expected.json
+++ b/tests/marathon_one_app_missing_data_expected.json
@@ -1,0 +1,63 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_80_0_http"
+            ],
+            "name": "server-app_80"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_80",
+            "pool": "/mesos/server-app_80",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_one_app_no_port_label_expected.json
+++ b/tests/marathon_one_app_no_port_label_expected.json
@@ -1,0 +1,90 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_10001_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31132,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31615,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_10001_0_http"
+            ],
+            "name": "server-app_10001"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:10001",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_10001",
+            "pool": "/mesos/server-app_10001",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_one_app_pool_only_expected.json
+++ b/tests/marathon_one_app_pool_only_expected.json
@@ -1,0 +1,68 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31132,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31615,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_80_0_http"
+            ],
+            "name": "server-app_80"
+        }
+    ],
+    "virtualServers": []
+}

--- a/tests/marathon_one_app_two_health_checks.json
+++ b/tests/marathon_one_app_two_health_checks.json
@@ -127,8 +127,8 @@
             },
             {
                 "path": "/",
-                "protocol": "HTTPS",
-                "portIndex": 1,
+                "protocol": "TCP",
+                "portIndex": 0,
                 "gracePeriodSeconds": 300,
                 "intervalSeconds": 60,
                 "timeoutSeconds": 20,

--- a/tests/marathon_one_app_two_health_checks_expected.json
+++ b/tests/marathon_one_app_two_health_checks_expected.json
@@ -1,0 +1,132 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 300,
+            "ignoreHttp1xx": false,
+            "interval": 60,
+            "intervalSeconds": 60,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 141,
+            "timeoutSeconds": 20,
+            "type": "http"
+        },
+        {
+            "gracePeriodSeconds": 300,
+            "ignoreHttp1xx": false,
+            "interval": 60,
+            "intervalSeconds": 60,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_1_tcp",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "TCP",
+            "timeout": 141,
+            "timeoutSeconds": 20,
+            "type": "tcp"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31132,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31615,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_80_0_http",
+                "/mesos/server-app_80_1_tcp"
+            ],
+            "name": "server-app_80"
+        },
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [],
+            "monitors": [],
+            "name": "server-app_443"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_80",
+            "pool": "/mesos/server-app_80",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        },
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:443",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_443",
+            "pool": "/mesos/server-app_443",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_one_app_two_service_ports_expected.json
+++ b/tests/marathon_one_app_two_service_ports_expected.json
@@ -1,0 +1,152 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app4_8080_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        },
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app4_8090_0_http",
+            "path": "/",
+            "portIndex": 1,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31144,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31390,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31581,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app4_8080_0_http"
+            ],
+            "name": "server-app4_8080"
+        },
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31145,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31391,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31582,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app4_8090_0_http"
+            ],
+            "name": "server-app4_8090"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:8080",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app4_8080",
+            "pool": "/mesos/server-app4_8080",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        },
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:8090",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app4_8090",
+            "pool": "/mesos/server-app4_8090",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_one_app_zero_instances_expected.json
+++ b/tests/marathon_one_app_zero_instances_expected.json
@@ -1,0 +1,53 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 10,
+            "intervalSeconds": 10,
+            "maxConsecutiveFailures": 1,
+            "name": "server-app_80_0_http",
+            "path": "/my_healthcheck",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 21,
+            "timeoutSeconds": 20,
+            "type": "http"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [],
+            "monitors": [
+                "/mesos/server-app_80_0_http"
+            ],
+            "name": "server-app_80"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_80",
+            "pool": "/mesos/server-app_80",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/marathon_two_apps_expected.json
+++ b/tests/marathon_two_apps_expected.json
@@ -1,0 +1,152 @@
+{
+    "iapps": [],
+    "l7Policies": [],
+    "monitors": [
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app_80_0_http",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "http"
+        },
+        {
+            "gracePeriodSeconds": 5,
+            "ignoreHttp1xx": false,
+            "interval": 20,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "name": "server-app2_8080_0_tcp",
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "TCP",
+            "timeout": 61,
+            "timeoutSeconds": 20,
+            "type": "tcp"
+        }
+    ],
+    "pools": [
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31972,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31982,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app_80_0_http"
+            ],
+            "name": "server-app_80"
+        },
+        {
+            "loadBalancingMode": "round-robin",
+            "members": [
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31126,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31151,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31345,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                },
+                {
+                    "address": "10.141.141.10",
+                    "connectionLimit": 0,
+                    "port": 31701,
+                    "priorityGroup": 0,
+                    "rateLimit": 0,
+                    "ratio": 1,
+                    "session": "user-enabled"
+                }
+            ],
+            "monitors": [
+                "/mesos/server-app2_8080_0_tcp"
+            ],
+            "name": "server-app2_8080"
+        }
+    ],
+    "virtualServers": [
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:80",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app_80",
+            "pool": "/mesos/server-app_80",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        },
+        {
+            "connectionLimit": 0,
+            "destination": "/mesos/10.128.10.240:8080",
+            "enabled": true,
+            "ipProtocol": "tcp",
+            "name": "server-app2_8080",
+            "pool": "/mesos/server-app2_8080",
+            "profiles": [
+                {
+                    "name": "http",
+                    "partition": "Common"
+                },
+                {
+                    "name": "tcp",
+                    "partition": "Common"
+                }
+            ],
+            "sourceAddressTranslation": {
+                "type": "automap"
+            }
+        }
+    ]
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -29,11 +29,31 @@ import time
 from sseclient import Event
 from mock import Mock, mock_open, patch
 from f5_cccl.common import DCOSAuth, get_marathon_auth_params, setup_logging
-from f5.bigip import BigIP
-from f5_cccl._f5 import CloudBigIP, get_protocol
+from f5.bigip import ManagementRoot
+from f5_cccl.api import F5CloudServiceManager
+from f5_cccl.exceptions import F5CcclValidationError
+from f5_cccl.exceptions import F5CcclSchemaError
 from StringIO import StringIO
-from f5_cccl.testcommon import BigIPTest, HealthCheck, Pool
 ctlr = __import__('marathon-bigip-ctlr')
+
+schema_path = "/src/f5-cccl/f5_cccl/schemas/cccl-api-schema.yml"
+
+# Marathon app data
+marathon_test_data = [
+    'tests/marathon_one_app_in_subdir.json',
+    'tests/marathon_invalid_apps.json',
+    'tests/marathon_two_apps.json',
+    'tests/marathon_app_no_hm.json',
+    'tests/marathon_one_app_missing_data.json',
+    'tests/marathon_one_app_no_port_label.json',
+    'tests/marathon_one_app_two_service_ports.json',
+    'tests/marathon_app_with_one_unconfig_service_port.json',
+    'tests/marathon_no_apps.json',
+    'tests/marathon_one_app_zero_instances.json',
+    'tests/marathon_one_app_https.json',
+    'tests/marathon_one_app_two_health_checks.json',
+    'tests/marathon_one_app_pool_only.json'
+]
 
 args_env = ['F5_CC_SYSLOG_SOCKET',
             'F5_CC_LOG_FORMAT',
@@ -156,7 +176,7 @@ class ArgTest(unittest.TestCase):
         """Test: No username arg."""
         # Invalid scheme
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--hostname', 'scheme://10.10.1.145',
                 '--password', 'default']
         sys.argv[0:] = self._args_app_name + args
@@ -166,7 +186,7 @@ class ArgTest(unittest.TestCase):
         """Test: No password arg."""
         # Invalid scheme
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--username', 'admin',
                 '--hostname', 'scheme://10.10.1.145']
         sys.argv[0:] = self._args_app_name + args
@@ -176,7 +196,7 @@ class ArgTest(unittest.TestCase):
         """Test: Hostname arg."""
         # No hostname
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--username', 'admin',
                 '--password', 'default']
         sys.argv[0:] = self._args_app_name + args
@@ -184,7 +204,7 @@ class ArgTest(unittest.TestCase):
 
         # Invalid scheme
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--hostname', 'scheme://10.10.1.145',
                 '--username', 'admin',
                 '--password', 'default']
@@ -193,7 +213,7 @@ class ArgTest(unittest.TestCase):
 
         # No scheme
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--hostname', '10.10.1.145',
                 '--username', 'admin',
                 '--password', 'default']
@@ -204,7 +224,7 @@ class ArgTest(unittest.TestCase):
 
         # No port
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--hostname', 'https://10.10.1.145',
                 '--username', 'admin',
                 '--password', 'default']
@@ -215,7 +235,7 @@ class ArgTest(unittest.TestCase):
 
         # Given port
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--hostname', 'https://10.10.1.145:555',
                 '--username', 'admin',
                 '--password', 'default']
@@ -226,7 +246,7 @@ class ArgTest(unittest.TestCase):
 
         # Invalid path
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--hostname', 'https://10.10.1.145/path/not/allowed',
                 '--username', 'admin',
                 '--password', 'default']
@@ -236,13 +256,13 @@ class ArgTest(unittest.TestCase):
     def test_partition_arg(self):
         """Test: Wildcard partition arg."""
         args = ['--marathon', 'http://10.0.0.10:8080',
-                '--partition', '*',
+                '--partition', 'test',
                 '--hostname', '10.10.1.145',
                 '--username', 'admin',
                 '--password', 'default']
         sys.argv[0:] = self._args_app_name + args
         args = ctlr.parse_args()
-        self.assertEqual(args.partition, ['*'])
+        self.assertEqual(args.partition, ['test'])
 
         # No partition specified
         args = ['--marathon', 'http://10.0.0.10:8080',
@@ -253,11 +273,11 @@ class ArgTest(unittest.TestCase):
         self.assertRaises(SystemExit, ctlr.parse_args)
 
         # test via env var
-        partitions_env = '*'
+        partitions_env = 'test'
         sys.argv[0:] = self._args_app_name + self._args_without_partition
         os.environ['F5_CC_PARTITIONS'] = partitions_env
         args = ctlr.parse_args()
-        self.assertEqual(args.partition, ['*'])
+        self.assertEqual(args.partition, ['test'])
 
     def test_multiple_partition_arg(self):
         """Test: Multiple partition args."""
@@ -627,22 +647,31 @@ class ArgTest(unittest.TestCase):
         self.assertEqual(args.log_level, getattr(logging, 'DEBUG'))
 
 
-class MarathonTest(BigIPTest):
+class MarathonTest(unittest.TestCase):
     """Marathon/Big-IP configuration tests.
 
-    Test BIG-IP configuration given various Marathon states and existing
-    BIG-IP states
+    Test BIG-IP configuration given various Marathon states
     """
 
     def setUp(self):
         """Test suite set up."""
         # Mock the call to _get_tmos_version(), which tries to make a
         # connection
-        partition = 'mesos'
-        with patch.object(BigIP, '_get_tmos_version'):
-            bigip = CloudBigIP('1.2.3.4', '443', 'admin',
-                               'default', [partition])
-        super(MarathonTest, self).setUp(partition, bigip)
+        with patch.object(ManagementRoot, '_get_tmos_version'):
+            bigip = ManagementRoot(
+                '1.2.3.4',
+                'admin',
+                'admin',
+                port=443,
+                token='tmos')
+            self.cccl = F5CloudServiceManager(
+                bigip,
+                'mesos',
+                prefix='',
+                schema_path=schema_path)
+        self.cccl._service_manager._service_deployer._bigip.refresh = Mock()
+        self.cccl._service_manager._service_deployer.deploy = \
+            Mock(return_value=0)
 
     def raiseSystemExit(self):
         """Raise a SystemExit exception."""
@@ -668,49 +697,35 @@ class MarathonTest(BigIPTest):
                 else:
                     self.assertEqual(app['ports'][0], service.servicePort)
 
-    def test_exceptions(self, cloud_state='tests/marathon_two_apps.json',
-                        bigip_state='tests/bigip_test_no_change.json',
-                        hm_state='tests/bigip_test_two_monitors.json'):
-        """Test: Exception handling."""
+    def read_test_vectors(self, cloud_state):
+        """Read test vectors for the various states."""
+        # Read the Marathon state
+        if cloud_state:
+            with open(cloud_state) as json_data:
+                self.cloud_data = json.load(json_data)
+
+    def verify_marathon_config(self, cloud_state, expected_state):
+        """Test: Verify expected config is created from the Marathon state."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
+
+        # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
-        # Successful configuration (no retry)
-        self.assertFalse(self.bigip.regenerate_config_f5(cfg))
+        self.check_labels(self.cloud_data, apps)
 
-        # BIG-IP related exception (retry)
-        self.bigip._apply_config = Mock(side_effect=self.raiseSDKError)
-        self.assertTrue(self.bigip.regenerate_config_f5(cfg))
-
-        # BIG-IP related exception (retry)
-        self.bigip._apply_config = \
-            Mock(side_effect=self.raiseConnectionError)
-        self.assertTrue(self.bigip.regenerate_config_f5(cfg))
-
-        # BIG-IP related exception (retry)
-        self.bigip._apply_config = \
-            Mock(side_effect=self.raiseBigIPInvalidURL)
-        self.assertTrue(self.bigip.regenerate_config_f5(cfg))
-
-        # BIG-IP related exception (retry)
-        self.bigip._apply_config = \
-            Mock(side_effect=self.raiseBigiControlUnexpectedHTTPError)
-        self.assertTrue(self.bigip.regenerate_config_f5(cfg))
-
-        # Other exception types (retry)
-        self.bigip._apply_config = Mock(side_effect=self.raiseTypeError)
-        self.assertTrue(self.bigip.regenerate_config_f5(cfg))
+        with open(expected_state) as json_data:
+                exp = json.load(json_data)
+        self.assertEqual(cfg, exp)
 
     def test_marathon_objects(
             self,
-            cloud_state='tests/marathon_one_app_in_subdir.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
+            cloud_state='tests/marathon_one_app_in_subdir.json'):
         """Test: Verify magic methods of app, service and backend objects."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
 
         app_data = self.cloud_data
         for app in app_data:
@@ -726,861 +741,106 @@ class MarathonTest(BigIPTest):
         self.assertEquals(repr(apps[1].backends.pop()),
                           "MarathonBackend(u'10.141.141.10', 31982)")
 
-    def test_app_frontend_name(
-            self,
-            cloud_state='tests/marathon_one_app_in_subdir.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Verify frontend name when the app is in a subdirectory."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-
-        expected_name = 'my_services_test-2_server-app_80'
-        self.assertEquals(1, len(self.test_virtual))
-        self.assertEquals(1, len(self.test_pool))
-        self.assertEquals(expected_name, self.test_virtual[0]['name'])
-        self.assertEquals(self.test_partition,
-                          self.test_virtual[0]['partition'])
-        self.assertEquals(expected_name, self.test_pool[0]['name'])
-        self.assertEquals(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEquals(self.bigip.member_create.call_args[0][1],
-                          expected_name)
-
-    def test_invalid_app(self,
-                         cloud_state='tests/marathon_invalid_apps.json',
-                         bigip_state='tests/bigip_test_blank.json',
-                         hm_state='tests/bigip_test_blank.json'):
-        """Test: Invalid marathon applications are not configured."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.member_create.call_count, 3)
-
-        self.assertEquals(1, len(self.test_virtual))
-        self.assertEquals(1, len(self.test_pool))
-        self.assertEquals(1, len(self.test_monitor))
-
-        expected_name = 'server-app_80'
-
-        self.assertEquals(expected_name, self.test_virtual[0]['name'])
-        self.assertEquals(expected_name, self.test_pool[0]['name'])
-        self.assertEquals(expected_name, self.test_monitor[0]['name'])
-        self.assertEquals(self.test_partition,
-                          self.test_virtual[0]['partition'])
-        self.assertEquals(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEquals(self.test_partition,
-                          self.test_monitor[0]['partition'])
-
-    def test_no_change(self, cloud_state='tests/marathon_two_apps.json',
-                       bigip_state='tests/bigip_test_no_change.json',
-                       hm_state='tests/bigip_test_two_monitors.json'):
-        """Test: No Marathon state change."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-
-    def test_app_destroyed(self, cloud_state='tests/marathon_one_app.json',
-                           bigip_state='tests/bigip_test_app_destroyed.json',
-                           hm_state='tests/bigip_test_two_monitors.json'):
-        """Test: Marathon app destroyed."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertTrue(self.bigip.ltm.pools.get_collection.called)
-        self.assertTrue(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.load.call_count, 1)
-        self.assertEqual(self.bigip.ltm.pools.get_collection.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.tcps.tcp.load.call_count, 1)
-
-    def test_app_scaled_up(self,
-                           cloud_state='tests/marathon_app_scaled.json',
-                           bigip_state='tests/bigip_test_app_scaled_up.json',
-                           hm_state='tests/bigip_test_two_monitors.json'):
-        """Test: Marathon app destroyed."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEqual(self.bigip.member_create.call_count, 2)
-
-    def test_app_scaled_down(
-            self,
-            cloud_state='tests/marathon_two_apps.json',
-            bigip_state='tests/bigip_test_app_scaled_down.json',
-            hm_state='tests/bigip_test_two_monitors.json'):
-        """Test: Marathon app scaled down."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertTrue(self.bigip.member_delete.called)
-        self.assertEqual(self.bigip.member_delete.call_count, 2)
-
-    def test_start_app_with_health_monitor_tcp(
-            self,
-            cloud_state='tests/marathon_two_apps.json',
-            bigip_state='tests/bigip_test_app_started_with_tcp.json',
-            hm_state='tests/bigip_test_one_http_monitor.json'):
-        """Test: Start Marathon app with a TCP health monitor."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEquals(self.bigip.ltm.virtuals.virtual.create.call_count,
-                          1)
-        self.assertEquals(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEquals(self.bigip.member_create.call_count, 4)
-        self.assertEquals(self.bigip.ltm.monitor.tcps.tcp.create.call_count, 1)
-
-    def test_start_app_with_health_monitor_http(
-            self,
-            cloud_state='tests/marathon_two_apps.json',
-            bigip_state='tests/bigip_test_app_started_with_http.json',
-            hm_state='tests/bigip_test_one_tcp_monitor.json'):
-        """Test: Start Marathon app with an HTTP health monitor."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEquals(self.bigip.ltm.virtuals.virtual.create.call_count,
-                          1)
-        self.assertEquals(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEquals(self.bigip.member_create.call_count, 2)
-        self.assertEquals(self.bigip.ltm.monitor.https.http.create.call_count,
-                          1)
-
-    def test_start_app_with_health_monitor_none(
-            self,
-            cloud_state='tests/marathon_app_no_hm.json',
-            bigip_state='tests/bigip_test_one_app.json',
-            hm_state='tests/bigip_test_one_http_monitor.json'):
-        """Test: Start Marathon app with no health monitor configured."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEquals(self.bigip.ltm.virtuals.virtual.create.call_count,
-                          1)
-        self.assertEquals(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEquals(self.bigip.member_create.call_count, 2)
-
-    def test_bigip_new(self, cloud_state='tests/marathon_two_apps.json',
-                       bigip_state='tests/bigip_test_blank.json',
-                       hm_state='tests/bigip_test_blank.json'):
-        """Test: BIG-IP with no resources previously configured."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertTrue(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertEquals(self.bigip.ltm.virtuals.virtual.create.call_count,
-                          2)
-        self.assertEquals(self.bigip.ltm.pools.pool.create.call_count, 2)
-        self.assertEquals(self.bigip.member_create.call_count, 6)
-        self.assertEquals(self.bigip.ltm.monitor.tcps.tcp.create.call_count, 1)
-        self.assertEquals(self.bigip.ltm.monitor.https.http.create.call_count,
-                          1)
-
-    def test_missing_task_data(
-            self,
-            cloud_state='tests/marathon_one_app_missing_data.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Tasks missing health-check results, hosts, and not 'alive'."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertEquals(self.bigip.ltm.virtuals.virtual.create.call_count,
-                          1)
-        self.assertEquals(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEquals(self.bigip.member_create.call_count, 1)
-
-    def test_no_port_override(
-            self,
-            cloud_state='tests/marathon_one_app_no_port_label.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Start Marathon app using default Marathon service port."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertEquals(self.bigip.member_create.call_count, 4)
-        self.assertEquals(self.bigip.ltm.monitor.https.http.create.call_count,
-                          1)
-
-        # No override of service port from Marathon
-        expected_name = 'server-app_10001'
-        self.assertEquals(1, len(self.test_virtual))
-        self.assertEquals(1, len(self.test_pool))
-        self.assertEquals(expected_name, self.test_virtual[0]['name'])
-        self.assertEquals(self.test_partition,
-                          self.test_virtual[0]['partition'])
-        self.assertEquals(expected_name, self.test_pool[0]['name'])
-        self.assertEquals(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEquals(self.bigip.member_create.call_args[0][1],
-                          expected_name)
-
-    def test_start_app_with_two_service_ports_and_two_hm(
-            self,
-            cloud_state='tests/marathon_one_app_two_service_ports.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Start Marathon app with two service ports."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEquals(self.bigip.member_create.call_count, 6)
-
-        expected_name1 = 'server-app4_8080'
-        expected_name2 = 'server-app4_8090'
-        self.assertEquals(2, len(self.test_virtual))
-        self.assertEquals(2, len(self.test_pool))
-        self.assertEquals(2, len(self.test_monitor))
-        self.assertEquals(expected_name1, self.test_virtual[0]['name'])
-        self.assertEquals(expected_name2, self.test_virtual[1]['name'])
-        self.assertEquals(self.test_partition,
-                          self.test_virtual[0]['partition'])
-        self.assertEquals(self.test_partition,
-                          self.test_virtual[1]['partition'])
-        self.assertEquals(expected_name1, self.test_pool[0]['name'])
-        self.assertEquals(expected_name2, self.test_pool[1]['name'])
-        self.assertEquals(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEquals(self.test_partition, self.test_pool[1]['partition'])
-        self.assertEquals(expected_name1, self.test_monitor[0]['name'])
-        self.assertEquals(expected_name2, self.test_monitor[1]['name'])
-        self.assertEquals(self.test_partition,
-                          self.test_monitor[0]['partition'])
-        self.assertEquals(self.test_partition,
-                          self.test_monitor[1]['partition'])
-
-    def start_two_apps_with_two_partitions(
-            self, partitions, expected_name1, expected_name2,
-            cloud_state='tests/marathon_two_apps_two_partitions.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
+    def test_marathon_configs(self):
+        """Test: Verify expected BIG-IP config created from Marathon state."""
+        # Verify configuration
+        for data_file in marathon_test_data:
+            expected_file = data_file.replace('.json', '_expected.json')
+            self.verify_marathon_config(data_file, expected_file)
+
+    def start_two_apps_with_multiple_partitions(
+            self, partitions, expected_name1, expected_partition1,
+            expected_name1_count, expected_name2, expected_partition2,
+            expected_name2_count,
+            cloud_state='tests/marathon_two_apps_two_partitions.json'):
         """Test: Start two Marathon apps on two partitions."""
-        # Setup two partitions
-        self.bigip._partitions = partitions
-
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
+        self.read_test_vectors(cloud_state)
         apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
         self.check_labels(self.cloud_data, apps)
 
+        name1_count = 0
+        name2_count = 0
+
+        # Create CCCL instance for each partition and count the number of
+        # times the virtual-server name is found
+        for partition in partitions:
+            with patch.object(ManagementRoot, '_get_tmos_version'):
+                bigip = ManagementRoot(
+                    '1.2.3.4',
+                    'admin',
+                    'default',
+                    port=443,
+                    token='tmos')
+                cccl = F5CloudServiceManager(
+                    bigip,
+                    partition,
+                    prefix='',
+                    schema_path=schema_path)
+
+                cfg = ctlr.create_config_marathon(cccl, apps)
+                if len(cfg['virtualServers']) > 0:
+                    if expected_name1 == cfg['virtualServers'][0]['name'] and \
+                            expected_partition1 == cccl.get_partition():
+                        name1_count += 1
+                    if expected_name2 == cfg['virtualServers'][0]['name'] and \
+                            expected_partition2 == cccl.get_partition():
+                        name2_count += 1
+
         # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        create_call_count = 0
-
-        if expected_name1:
-            create_call_count += 1
-            self.assertEquals(expected_name1,
-                              self.test_virtual[create_call_count - 1]['name'])
-            self.assertEquals(expected_name1,
-                              self.test_pool[create_call_count - 1]['name'])
-            self.assertEquals(expected_name1,
-                              self.test_monitor[create_call_count - 1]['name'])
-
-        if expected_name2:
-            create_call_count += 1
-            self.assertEquals(expected_name2,
-                              self.test_virtual[create_call_count - 1]['name'])
-            self.assertEquals(expected_name2,
-                              self.test_pool[create_call_count - 1]['name'])
-            self.assertEquals(expected_name2,
-                              self.test_monitor[create_call_count - 1]['name'])
-
-        if create_call_count > 0:
-            self.assertTrue(self.bigip.member_create.called)
-        else:
-            self.assertFalse(self.bigip.member_create.called)
-
-        self.assertEquals(create_call_count, len(self.test_virtual))
-        self.assertEquals(create_call_count, len(self.test_pool))
-        self.assertEquals(self.bigip.member_create.call_count,
-                          3*create_call_count)
-        self.assertEquals(create_call_count, len(self.test_monitor))
+        self.assertEqual(expected_name1_count, name1_count)
+        self.assertEqual(expected_name2_count, name2_count)
 
     def test_start_two_apps_with_two_matching_partitions(self):
         """Test: Start two Marathon apps on two partitions."""
-        self.start_two_apps_with_two_partitions(
+        self.start_two_apps_with_multiple_partitions(
             ['mesos', 'mesos2'],
-            'server-app_80',
-            'server-app1_80')
-
-    def test_start_two_apps_with_wildcard_partitions(self):
-        """Test: Start two Marathon apps, all partitions managed."""
-        self.start_two_apps_with_two_partitions(
-            ['*'],
-            'server-app_80',
-            'server-app1_80')
+            'server-app_80', 'mesos', 1,
+            'server-app1_80', 'mesos2', 1)
 
     def test_start_two_apps_with_three_partitions(self):
         """Test: Start two Marathon apps, three partitions managed."""
-        self.start_two_apps_with_two_partitions(
+        self.start_two_apps_with_multiple_partitions(
             ['mesos', 'mesos2', 'mesos3'],
-            'server-app_80',
-            'server-app1_80')
+            'server-app_80', 'mesos', 1,
+            'server-app1_80', 'mesos2', 1)
 
     def test_start_two_apps_with_one_matching_partition(self):
         """Test: Start two Marathon apps, one managed partition matches."""
-        self.start_two_apps_with_two_partitions(
+        self.start_two_apps_with_multiple_partitions(
             ['mesos', 'mesos1', 'mesos3'],
-            None,
-            'server-app_80')
+            'server-app_80', 'mesos', 1,
+            'server-app1_80', 'mesos2', 0)
 
     def test_start_two_apps_with_no_matching_partitions(self):
         """Test: Start two Marathon apps, no managed partitions match."""
-        self.start_two_apps_with_two_partitions(
+        self.start_two_apps_with_multiple_partitions(
             ['mesos0', 'mesos1', 'mesos3'],
-            None,
-            None)
+            'server-app_80', 'mesos', 0,
+            'server-app1_80', 'mesos2', 0)
 
-    def test_start_two_apps_with_no_partitions_configured(self):
-        """Test: Start two Marathon apps, no partitions managed."""
-        self.start_two_apps_with_two_partitions(
-            [],
-            None,
-            None)
-
-    def test_start_app_with_one_unconfigured_service_ports(
-            self,
-            cloud_state='tests/'
-            'marathon_app_with_one_unconfig_service_port.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Start Marathon apps with one uncofigured service port."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEquals(self.bigip.member_create.call_count, 6)
-
-        expected_name1 = 'server-app4_8080'
-        expected_name2 = 'server-app4_8090'
-        expected_name3 = 'server-app4_10003'
-        self.assertEquals(2, len(self.test_virtual))
-        self.assertEquals(3, len(self.test_pool))
-        self.assertEquals(expected_name1, self.test_virtual[0]['name'])
-        self.assertEquals(expected_name2, self.test_virtual[1]['name'])
-        self.assertEquals(self.test_partition,
-                          self.test_virtual[0]['partition'])
-        self.assertEquals(self.test_partition,
-                          self.test_virtual[1]['partition'])
-        self.assertEquals(expected_name1, self.test_pool[0]['name'])
-        self.assertEquals(expected_name2, self.test_pool[1]['name'])
-        self.assertEquals(expected_name3, self.test_pool[2]['name'])
-        self.assertEquals(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEquals(self.test_partition, self.test_pool[1]['partition'])
-        self.assertEquals(self.test_partition, self.test_pool[2]['partition'])
-        self.assertEquals(expected_name1, self.test_monitor[0]['name'])
-        self.assertEquals(expected_name2, self.test_monitor[1]['name'])
-        self.assertEquals(expected_name3, self.test_monitor[2]['name'])
-        self.assertEquals(self.test_partition,
-                          self.test_monitor[0]['partition'])
-        self.assertEquals(self.test_partition,
-                          self.test_monitor[1]['partition'])
-        self.assertEquals(self.test_partition,
-                          self.test_monitor[2]['partition'])
-
-    def test_destroy_all_apps(
-            self,
-            cloud_state='tests/marathon_no_apps.json',
-            bigip_state='tests/bigip_test_no_change.json',
-            hm_state='tests/bigip_test_two_monitors.json'):
-        """Test: Destroy all Marathon apps."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertEquals(self.bigip.member_delete.call_count, 0)
-
-        expected_name1 = 'server-app2_8080'
-        expected_name2 = 'server-app_80'
-        self.assertEquals(2, len(self.test_virtual))
-        self.assertEquals(2, len(self.test_pool))
-        self.assertEquals(2, len(self.test_monitor))
-        self.assertEquals(expected_name1, self.test_virtual[1].name)
-        self.assertEquals(expected_name2, self.test_virtual[0].name)
-        self.assertEquals(expected_name1, self.test_pool[1].name)
-        self.assertEquals(expected_name2, self.test_pool[0].name)
-        self.assertEquals(expected_name1, self.test_monitor[1].name)
-        self.assertEquals(expected_name2, self.test_monitor[0].name)
-
-    def test_app_suspended(
-            self,
-            cloud_state='tests/marathon_one_app_zero_instances.json',
-            bigip_state='tests/bigip_test_one_app.json',
-            hm_state='tests/bigip_test_one_http_monitor.json'):
-        """Test: Suspend Marathon app."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertTrue(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertEquals(self.bigip.member_delete.call_count, 4)
-
-        expected_name = 'server-app_80'
-        self.assertEquals(self.bigip.member_delete.call_args_list[0][0][1],
-                          expected_name)
-
-    def test_new_iapp(self, cloud_state='tests/marathon_one_iapp.json',
-                      bigip_state='tests/bigip_test_blank.json',
-                      hm_state='tests/bigip_test_blank.json'):
+    def test_new_iapp(self, cloud_state='tests/marathon_one_iapp.json'):
         """Test: Start Marathon app with iApp."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        self.bigip.iapp_create = self.bigip.iapp_create_orig
-        self.bigip.sys.application.services.service.create = \
-            Mock(side_effect=self.mock_iapp_service_create)
-        self.bigip.virtual_delete = Mock(side_effect=self.mock_virtual_delete)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, False)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
         self.check_labels(self.cloud_data, apps)
 
         # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.virtual_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-
         expected_name = 'server-app2_10000'
 
         # Verfiy the iapp variables and tables
         expected_tables = \
             [{'columnNames': ['addr', 'port', 'connection_limit'], 'rows':
-              [{'row': ['10.141.141.10', '31698', '0']},
+              [{'row': ['10.141.141.10', '31256', '0']},
                {'row': ['10.141.141.10', '31269', '0']},
-               {'row': ['10.141.141.10', '31748', '0']},
-               {'row': ['10.141.141.10', '31256', '0']}],
+               {'row': ['10.141.141.10', '31698', '0']},
+               {'row': ['10.141.141.10', '31748', '0']}],
                 'name': u'pool__members'}]
         expected_variables = \
             [{'name': u'monitor__monitor', 'value': u'/#create_new#'},
@@ -1592,9 +852,10 @@ class MarathonTest(BigIPTest):
              {'name': u'monitor__uri', 'value': u'/'},
              {'name': u'pool__port', 'value': u'8080'}]
 
-        self.assertEquals(expected_name, self.test_iapp.name)
-        self.assertEquals(expected_tables, self.test_iapp.tables)
-        self.assertEquals(expected_variables, self.test_iapp.variables)
+        # Verify the iapp variables and tables
+        self.assertEquals(expected_name, cfg['iapps'][0]['name'])
+        self.assertEquals(expected_tables, cfg['iapps'][0]['tables'])
+        self.assertEquals(expected_variables, cfg['iapps'][0]['variables'])
 
     def check_expected_iapp_poolmember_table(self, pool_member_table_input,
                                              expected_tables):
@@ -1607,11 +868,9 @@ class MarathonTest(BigIPTest):
             BIG-IP (compared with assertEquals).
         """
         cloud_state = 'tests/marathon_one_iapp_column_names.json'
-        bigip_state = 'tests/bigip_test_blank.json'
-        hm_state = 'tests/bigip_test_blank.json'
 
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
 
         # Overload the pool member table label - this tells the controller how
         # to fill in the pool member table.  Properly interpreting this is
@@ -1619,22 +878,18 @@ class MarathonTest(BigIPTest):
         self.cloud_data[0]['labels']['F5_0_IAPP_POOL_MEMBER_TABLE'] = \
             json.dumps(pool_member_table_input)
 
-        self.bigip.iapp_create = self.bigip.iapp_create_orig
-        self.bigip.sys.application.services.service.create = \
-            Mock(side_effect=self.mock_iapp_service_create)
-
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, False)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
         self.check_labels(self.cloud_data, apps)
 
         expected_name = 'server-app2_10000'
 
         # Verify the iapp variables and tables
-        self.assertEquals(expected_name, self.test_iapp.name)
-        self.assertEquals(expected_tables, self.test_iapp.tables)
+        self.assertEquals(expected_name, cfg['iapps'][0]['name'])
+        self.assertEquals(expected_tables, cfg['iapps'][0]['tables'])
 
     def test_new_iapp_nondefault_column_names(self):
         """Test: Marathon app with iApp, override pool-member column names."""
@@ -1649,10 +904,10 @@ class MarathonTest(BigIPTest):
         expected_tables = \
             [{'columnNames': [u'IPAddress', u'Port', u'ConnectionLimit'],
               'rows':
-              [{'row': ['10.141.141.10', '31698', '0']},
+              [{'row': ['10.141.141.10', '31256', '0']},
                {'row': ['10.141.141.10', '31269', '0']},
-               {'row': ['10.141.141.10', '31748', '0']},
-               {'row': ['10.141.141.10', '31256', '0']}],
+               {'row': ['10.141.141.10', '31698', '0']},
+               {'row': ['10.141.141.10', '31748', '0']}],
                 'name': u'pool__members'}]
         self.check_expected_iapp_poolmember_table(
             pool_member_table_input,
@@ -1670,10 +925,10 @@ class MarathonTest(BigIPTest):
         expected_tables = \
             [{'columnNames': [u'IPAddress', u'Port'],
               'rows':
-              [{'row': ['10.141.141.10', '31698']},
+              [{'row': ['10.141.141.10', '31256']},
                {'row': ['10.141.141.10', '31269']},
-               {'row': ['10.141.141.10', '31748']},
-               {'row': ['10.141.141.10', '31256']}],
+               {'row': ['10.141.141.10', '31698']},
+               {'row': ['10.141.141.10', '31748']}],
                 'name': u'pool__members'}]
         self.check_expected_iapp_poolmember_table(
             pool_member_table_input,
@@ -1692,10 +947,10 @@ class MarathonTest(BigIPTest):
         expected_tables = \
             [{'columnNames': [u'ConnectionLimit', u'Port', u'IPAddress'],
               'rows':
-              [{'row': ['0', '31698', '10.141.141.10']},
+              [{'row': ['0', '31256', '10.141.141.10']},
                {'row': ['0', '31269', '10.141.141.10']},
-               {'row': ['0', '31748', '10.141.141.10']},
-               {'row': ['0', '31256', '10.141.141.10']}],
+               {'row': ['0', '31698', '10.141.141.10']},
+               {'row': ['0', '31748', '10.141.141.10']}],
                 'name': u'pool__members'}]
         self.check_expected_iapp_poolmember_table(
             pool_member_table_input,
@@ -1728,13 +983,13 @@ class MarathonTest(BigIPTest):
                 u'AdvOptions',
             ],
             'rows': [
-                {'row': ['0', '10.141.141.10', '31698', '1000', '1', '0',
+                {'row': ['0', '10.141.141.10', '31256', '1000', '1', '0',
                          'enabled', '']},
                 {'row': ['0', '10.141.141.10', '31269', '1000', '1', '0',
                          'enabled', '']},
-                {'row': ['0', '10.141.141.10', '31748', '1000', '1', '0',
+                {'row': ['0', '10.141.141.10', '31698', '1000', '1', '0',
                          'enabled', '']},
-                {'row': ['0', '10.141.141.10', '31256', '1000', '1', '0',
+                {'row': ['0', '10.141.141.10', '31748', '1000', '1', '0',
                          'enabled', '']},
             ],
             'name': u'pool__members'
@@ -1747,11 +1002,9 @@ class MarathonTest(BigIPTest):
                                             do_json=True):
         """Check that invalid pool member table formats fail cleanly."""
         cloud_state = 'tests/marathon_one_iapp_column_names.json'
-        bigip_state = 'tests/bigip_test_blank.json'
-        hm_state = 'tests/bigip_test_blank.json'
 
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
 
         # Overload the pool member table label - this tells the controller how
         # to fill in the pool member table.  Properly interpreting this is
@@ -1764,13 +1017,13 @@ class MarathonTest(BigIPTest):
 
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, False)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
         self.check_labels(self.cloud_data, apps)
 
-        # Should be 0 because parsing the table should have failed.
-        self.assertEquals(self.bigip.iapp_create.call_count, 0)
+        # Should be empty because parsing the table should have failed.
+        self.assertEquals(cfg['iapps'], [])
 
     def test_iapp_pool_member_table_not_json(self):
         """The pool member isn't JSON - should get an error."""
@@ -1857,11 +1110,9 @@ class MarathonTest(BigIPTest):
     def test_iapp_both_table_definitions(self):
         """Check that specifying both table types fails."""
         cloud_state = 'tests/marathon_one_iapp_column_names.json'
-        bigip_state = 'tests/bigip_test_blank.json'
-        hm_state = 'tests/bigip_test_blank.json'
 
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
 
         # Overload the pool member table label - this tells the controller how
         # to fill in the pool member table.  Properly interpreting this is
@@ -1881,31 +1132,25 @@ class MarathonTest(BigIPTest):
 
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, False)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
         self.check_labels(self.cloud_data, apps)
 
-        # Should be 0 because parsing the table should have failed.
-        self.assertEquals(self.bigip.iapp_create.call_count, 0)
+        # Should be empty because parsing the table should have failed.
+        self.assertEquals(cfg['iapps'], [])
 
     def test_new_iapp_with_tables(
             self,
-            cloud_state='tests/marathon_one_iapp_with_tables.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
+            cloud_state='tests/marathon_one_iapp_with_tables.json'):
         """Test: Marathon app with iApp with iApp tables."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        self.bigip.iapp_create = self.bigip.iapp_create_orig
-        self.bigip.sys.application.services.service.create = \
-            Mock(side_effect=self.mock_iapp_service_create)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, False)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
         self.check_labels(self.cloud_data, apps)
 
@@ -1915,10 +1160,10 @@ class MarathonTest(BigIPTest):
         expected_tables = \
             [{'columnNames': [u'addr', u'port', u'connection_limit'],
               'rows':
-              [{'row': ['10.141.141.10', '31698', '0']},
+              [{'row': ['10.141.141.10', '31256', '0']},
                {'row': ['10.141.141.10', '31269', '0']},
-               {'row': ['10.141.141.10', '31748', '0']},
-               {'row': ['10.141.141.10', '31256', '0']}],
+               {'row': ['10.141.141.10', '31698', '0']},
+               {'row': ['10.141.141.10', '31748', '0']}],
                 'name': u'pool__members'},
              {'columnNames': [u'Group', u'Operand', u'Negate', u'Condition',
                               u'Value', u'CaseSensitive', u'Missing'],
@@ -1934,245 +1179,9 @@ class MarathonTest(BigIPTest):
                         u'pool:0']}],
                 'name': u"'l7policy__rulesAction"}]
 
-        self.assertEquals(expected_name, self.test_iapp.name)
-        self.assertEquals(expected_tables, self.test_iapp.tables)
-
-    def test_delete_iapp(self, cloud_state='tests/marathon_no_apps.json',
-                         bigip_state='tests/bigip_test_blank.json',
-                         hm_state='tests/bigip_test_blank.json'):
-        """Test: Delete Marathon app associated with iApp."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        self.bigip.iapp_delete = self.bigip.iapp_delete_orig
-        self.bigip.sys.application.services.get_collection = \
-            Mock(side_effect=self.mock_iapp_services_get_collection)
-        self.bigip.sys.application.services.service.load = \
-            Mock(side_effect=self.mock_iapp_service_load)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        expected_name = 'server-app2_iapp_10000_vs'
-        self.assertEqual(len(self.test_iapp_list), 1)
-        self.assertEqual(self.test_iapp_list[0].partition,
-                         self.test_partition)
-        self.assertEqual(self.test_iapp_list[0].name, expected_name)
-        self.assertEqual(self.test_iapp.partition, self.test_partition)
-        self.assertEqual(self.test_iapp.name, expected_name)
-
-    def test_https_app(
-            self,
-            cloud_state='tests/marathon_one_app_https.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Start Marathon app that uses HTTPS."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        https_app_count = 0
-        for service, app in zip(self.cloud_data, apps):
-            labels = service['labels']
-            if labels.get('F5_0_BIND_ADDR') is not None:
-                self.assertEqual(labels.get('F5_PARTITION'), 'mesos')
-                self.assertEqual(labels.get('F5_0_BIND_ADDR'), '10.128.10.240')
-                self.assertEqual(labels.get('F5_0_MODE'), 'http')
-                self.assertEqual(labels.get('F5_0_SSL_PROFILE'),
-                                 'Common/clientssl')
-                self.assertEqual(labels.get('F5_PARTITION'), app.partition)
-                self.assertEqual(labels.get('F5_0_BIND_ADDR'), app.bindAddr)
-                self.assertEqual(labels.get('F5_0_MODE'), app.mode)
-                self.assertEqual(labels.get('F5_0_SSL_PROFILE'), app.profile)
-                https_app_count += 1
-
-        self.assertEqual(https_app_count, 1)
-
-    def test_updates(self,
-                     cloud_state='tests/marathon_one_app_https.json',
-                     bigip_state='tests/bigip_test_one_app.json',
-                     hm_state='tests/bigip_test_one_monitor.json'):
-        """Test: Verify BIG-IP updates.
-
-        Verify that resources are only updated when the state
-        of the resource changes.
-        """
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-
-        # Restore the mocked 'update' functions to their original state
-        self.bigip.pool_update = self.bigip.pool_update_orig
-        self.bigip.virtual_update = self.bigip.virtual_update_orig
-        self.bigip.member_update = self.bigip.member_update_orig
-        self.bigip.healthcheck_update = self.bigip.healthcheck_update_orig
-
-        # Mock the 'get' resource functions. We will use these to supply
-        # mocked resources
-        self.bigip.get_pool = Mock(side_effect=self.mock_get_pool)
-        self.bigip.get_virtual = Mock(side_effect=self.mock_get_virtual)
-        self.bigip.get_virtual_profiles = Mock(
-            side_effect=self.mock_get_virtual_profiles)
-        self.bigip.get_member = Mock(side_effect=self.mock_get_member)
-        self.bigip.get_healthcheck = Mock(
-            side_effect=self.mock_get_healthcheck)
-        self.bigip.get_virtual_address = Mock(
-            side_effect=self.mock_get_virtual_address)
-
-        # Create a mock Pool
-        pool_data_unchanged = {'monitor': '/mesos/server-app_80',
-                               'balance': 'round-robin'}
-        pool = self.create_mock_pool('server-app_80',
-                                     **pool_data_unchanged)
-
-        # Create a mock Virtual
-        virtual_data_unchanged = {'enabled': True,
-                                  'disabled': False,
-                                  'ipProtocol': 'tcp',
-                                  'destination': '/mesos/10.128.10.240:80',
-                                  'pool': '/mesos/server-app_80',
-                                  'sourceAddressTranslation':
-                                  {'type': 'automap'},
-                                  'profiles': [{'partition': 'Common',
-                                                'name': 'clientssl'},
-                                               {'partition': 'Common',
-                                                'name': 'http'}]}
-        virtual = self.create_mock_virtual('server-app_80',
-                                           **virtual_data_unchanged)
-
-        # Create mock Pool Members
-        member_data_unchanged = {'state': 'user-up', 'session': 'user-enabled'}
-        member = self.create_mock_pool_member('10.141.141.10:31132',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('10.141.141.10:31615',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('10.141.141.10:31982',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('10.141.141.10:31972',
-                                              **member_data_unchanged)
-
-        # Create a mock Healthcheck
-        health_data_unchanged = {
-            'interval': 20,
-            'timeout': 61,
-            'send': 'GET / HTTP/1.0\\r\\n\\r\\n'
-        }
-        healthcheck = self.create_mock_healthcheck(
-            'server-app_80', **health_data_unchanged)
-
-        # Pool, Virtual, Member, and Healthcheck are not modified
-        self.bigip.regenerate_config_f5(cfg)
-        self.assertFalse(pool.modify.called)
-        self.assertFalse(virtual.modify.called)
-        self.assertFalse(virtual.profiles_s.profiles.create.called)
-        self.assertFalse(member.modify.called)
-        self.assertFalse(healthcheck.modify.called)
-
-        # Pool is modified
-        pool_data_changed = {
-            'balance': 'least-connections',
-            'monitor': 'server-app_8080'
-        }
-        for key in pool_data_changed:
-            data = pool_data_unchanged.copy()
-            # Change one thing
-            data[key] = pool_data_changed[key]
-            pool = self.create_mock_pool('server-app_80', **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(pool.modify.called)
-
-        # Virtual is modified
-        virtual_data_changed = {
-            'enabled': False,
-            'disabled': True,
-            'ipProtocol': 'udp',
-            'destination': '/Common/10.128.10.240:80',
-            'pool': '/Common/server-app_80',
-            'sourceAddressTranslation': {'type': 'snat'},
-            'profiles': [{'partition': 'Common', 'name': 'clientssl'},
-                         {'partition': 'Common', 'name': 'tcp'}]
-        }
-        for key in virtual_data_changed:
-            data = virtual_data_unchanged.copy()
-            # Change one thing
-            data[key] = virtual_data_changed[key]
-            virtual = self.create_mock_virtual('server-app_80',
-                                               **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(virtual.modify.called)
-
-        # Member is modified
-        member_data_changed = {
-            'state': 'user-down',
-            'session': 'user-disabled'
-        }
-        for key in member_data_changed:
-            data = member_data_unchanged.copy()
-            # Change one thing
-            data[key] = member_data_changed[key]
-            member = self.create_mock_pool_member('10.141.141.10:31132',
-                                                  **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(member.modify.called)
-
-        # Healthcheck is modified
-        health_data_changed = {
-            'interval': 10,
-            'timeout': 30,
-            'send': 'GET /mypath HTTP/1.0\\r\\n\\r\\n'
-        }
-        for key in health_data_changed:
-            data = health_data_unchanged.copy()
-            # Change one thing
-            data[key] = health_data_changed[key]
-            healthcheck = self.create_mock_healthcheck(
-                'server-app_80', **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(healthcheck.modify.called)
-
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
+        # Verify the iapp tables
+        self.assertEquals(expected_name, cfg['iapps'][0]['name'])
+        self.assertEquals(expected_tables, cfg['iapps'][0]['tables'])
 
     def test_event_processor(self):
         """Test Marathon event processing."""
@@ -2192,7 +1201,7 @@ class MarathonTest(BigIPTest):
         ctlr.Marathon.health_check = Mock(return_value=True)
         ctlr.MarathonEventProcessor.start_checkpoint_timer = Mock()
         ctlr.MarathonEventProcessor.retry_backoff = Mock()
-        ep = ctlr.MarathonEventProcessor(marathon, 100, self.bigip)
+        ep = ctlr.MarathonEventProcessor(marathon, 100, [self.cccl])
 
         event_empty = Event(data='')
         event_app = Event(data='{"eventType": "app_terminated_event"}')
@@ -2201,34 +1210,27 @@ class MarathonTest(BigIPTest):
         event_invalid = Event(data='{"eventType": }')
         events = [event_empty, event_app, event_unknown, event_detached]
 
-        with patch.object(self.bigip, 'regenerate_config_f5',
-                          return_value=False):
-            ctlr.process_sse_events(ep, events, self.bigip)
+        with patch.object(self.cccl, 'apply_config',
+                          return_value=1):
+            ctlr.process_sse_events(ep, events)
             self.assertRaises(ValueError, ctlr.process_sse_events, ep,
-                              [event_invalid], self.bigip)
+                              [event_invalid])
             time.sleep(1)
 
-        with patch.object(self.bigip, 'regenerate_config_f5',
+        with patch.object(self.cccl, 'apply_config',
                           side_effect=requests.exceptions.ConnectionError):
-            ctlr.process_sse_events(ep, events, self.bigip)
+            ctlr.process_sse_events(ep, events)
             self.assertRaises(ValueError, ctlr.process_sse_events, ep,
-                              [event_invalid], self.bigip)
+                              [event_invalid])
             time.sleep(1)
 
-        with patch.object(self.bigip, 'regenerate_config_f5',
-                          side_effect=TypeError):
-            ctlr.process_sse_events(ep, events, self.bigip)
+        with patch.object(self.cccl, 'apply_config',
+                          side_effect=F5CcclValidationError):
+            ctlr.process_sse_events(ep, events)
             self.assertRaises(ValueError, ctlr.process_sse_events, ep,
-                              [event_invalid], self.bigip)
+                              [event_invalid])
             time.sleep(1)
 
-        with patch.object(self.bigip, 'regenerate_config_f5',
-                          return_value=True):
-            ctlr.process_sse_events(ep, events, self.bigip)
-            self.assertRaises(ValueError, ctlr.process_sse_events, ep,
-                              [event_invalid], self.bigip)
-
-            time.sleep(1)
             self.assertGreaterEqual(
                 ctlr.MarathonEventProcessor.start_checkpoint_timer.call_count,
                 1)
@@ -2255,107 +1257,20 @@ class MarathonTest(BigIPTest):
         self.assertEqual(ep._backoff_timer, 0.1)
         self.assertEqual(cb.call_count, 3)
 
-    def test_app_with_two_healthchecks(
-            self,
-            cloud_state='tests/marathon_one_app_two_health_checks.json',
-            bigip_state='tests/bigip_test_app_two_monitors.json',
-            hm_state='tests/bigip_test_one_app_two_monitors.json'):
-        """Test: Marathon app with one app and two health monitors."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertEqual(self.bigip.healthcheck_update.call_count, 2)
-        self.assertEqual(self.bigip.pool_update.call_count, 2)
-        health_checks = self.bigip.healthcheck_update.call_args_list
-        pool_list = self.bigip.get_pool_list("mesos")
-        for i in range(0, 1):
-            hc = health_checks[i][0][2]
-            name = hc['name']
-            self.assertTrue(name in self.hm_data)
-            self.assertTrue(name in pool_list)
-            self.assertEqual(hc['protocol'], self.hm_data[name]['type'])
-
-    def test_create_pool_only(
-            self,
-            cloud_state='tests/marathon_one_app_pool_only.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Marathon app that does not create a virtual server."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-        self.check_labels(self.cloud_data, apps)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 0)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
-
-        expected_name = 'server-app_80'
-        self.assertEqual(expected_name, self.test_pool[0]['name'])
-        self.assertEqual(expected_name, self.test_monitor[0]['name'])
-        self.assertEqual(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEqual(self.test_partition,
-                         self.test_monitor[0]['partition'])
-
     def test_pool_only_to_virtual_server(
             self,
-            cloud_state='tests/marathon_one_app_pool_only.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
+            cloud_state='tests/marathon_one_app_pool_only.json'):
         """Test: Marathon app without a virtual server gets virtual server."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Mock out functions not directly under test
-        self.bigip.get_pool_list = Mock(side_effect=self.mock_get_pool_list)
-        self.bigip.get_virtual_list = \
-            Mock(side_effect=self.mock_get_virtual_list)
-        self.bigip.get_healthcheck_list = \
-            Mock(side_effect=self.mock_get_healthcheck_list)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-        self.check_labels(self.cloud_data, apps)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
-        # Verify BIG-IP initial configuration
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 0)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
+        self.check_labels(self.cloud_data, apps)
+        self.assertEqual(len(cfg['virtualServers']), 0)
 
         # Reconfigure BIG-IP by adding virtual server to existing pool
         self.cloud_data[1]['labels'].update({unicode('F5_0_MODE'):
@@ -2363,453 +1278,70 @@ class MarathonTest(BigIPTest):
                                              unicode('F5_0_BIND_ADDR'):
                                              unicode('10.128.10.240')})
         apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
         self.check_labels(self.cloud_data, apps)
+        self.assertEqual(len(cfg['virtualServers']), 1)
 
         # Verify BIG-IP reconfiguration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
-
-        expected_name = 'server-app_80'
-        self.assertEqual(expected_name, self.test_pool[0]['name'])
-        self.assertEqual(expected_name, self.test_monitor[0]['name'])
-        self.assertEqual(expected_name, self.test_virtual[0]['name'])
-        self.assertEqual(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEqual(self.test_partition,
-                         self.test_monitor[0]['partition'])
-        self.assertEqual(self.test_partition,
-                         self.test_virtual[0]['partition'])
 
     def test_virtual_server_to_pool_only(
             self,
-            cloud_state='tests/marathon_one_app.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
+            cloud_state='tests/marathon_one_app.json'):
         """Test: Marathon app with virtual server removes virtual server."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Mock out functions not directly under test
-        self.bigip.get_pool_list = Mock(side_effect=self.mock_get_pool_list)
-        self.bigip.get_virtual_list = \
-            Mock(side_effect=self.mock_get_virtual_list)
-        self.bigip.get_healthcheck_list = \
-            Mock(side_effect=self.mock_get_healthcheck_list)
-        self.bigip.virtual_delete = Mock(side_effect=self.mock_virtual_delete)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-        self.check_labels(self.cloud_data, apps)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
 
-        # Verify BIG-IP initial configuration
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
+        self.check_labels(self.cloud_data, apps)
+        self.assertEqual(len(cfg['virtualServers']), 1)
 
         # Reconfigure BIG-IP by adding virtual server to existing pool
         self.cloud_data[1]['labels'].pop(unicode('F5_0_MODE'))
         self.cloud_data[1]['labels'].pop(unicode('F5_0_BIND_ADDR'))
         apps = ctlr.get_apps(self.cloud_data, True)
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
+        self.cccl.apply_config(cfg)
+
         self.check_labels(self.cloud_data, apps)
 
-        # Verify BIG-IP reconfiguration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
+        self.assertEqual(len(cfg['virtualServers']), 0)
 
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
+    def test_cccl_exceptions(self, cloud_state='tests/marathon_one_app.json'):
+        """Test: CCCL exceptions."""
+        with patch.object(ManagementRoot, '_get_tmos_version'):
+            bigip = ManagementRoot(
+                '1.2.3.4',
+                'admin',
+                'default',
+                port=443,
+                token='tmos')
+            self.assertRaises(F5CcclSchemaError, F5CloudServiceManager,
+                              bigip,
+                              'test',
+                              prefix="",
+                              schema_path='not/a/valid/path.json')
 
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
+        cfg = 'not valid json'
+        self.assertRaises(F5CcclValidationError, self.cccl.apply_config, cfg)
 
-        expected_name = 'server-app_80'
-        self.assertEqual(expected_name, self.test_pool[0]['name'])
-        self.assertEqual(expected_name, self.test_monitor[0]['name'])
-        self.assertEqual(self.test_partition, self.test_pool[0]['partition'])
-        self.assertEqual(self.test_partition,
-                         self.test_monitor[0]['partition'])
-        self.assertEqual(0, len(self.test_virtual))
+        cfg = '{}'
+        self.assertRaises(F5CcclValidationError, self.cccl.apply_config, cfg)
 
-    def test_updates_pool_only(
-            self,
-            cloud_state='tests/marathon_one_app_pool_only.json',
-            bigip_state='tests/bigip_test_one_app.json',
-            hm_state='tests/bigip_test_one_monitor.json'):
-        """Test: Verify BIG-IP updates in pool only mode.
-
-        Verify that resources are only updated when the state
-        of the resource changes.
-        """
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
         apps = ctlr.get_apps(self.cloud_data, True)
+        cfg = ctlr.create_config_marathon(self.cccl, apps)
 
-        # Restore the mocked 'update' functions to their original state
-        self.bigip.pool_update = self.bigip.pool_update_orig
-        self.bigip.member_update = self.bigip.member_update_orig
-        self.bigip.healthcheck_update = self.bigip.healthcheck_update_orig
-
-        # Mock the 'get' resource functions. We will use these to supply
-        # mocked resources
-        self.bigip.get_pool = Mock(side_effect=self.mock_get_pool)
-        self.bigip.get_virtual = Mock(side_effect=self.mock_get_virtual)
-        self.bigip.get_member = Mock(side_effect=self.mock_get_member)
-        self.bigip.get_healthcheck = Mock(
-            side_effect=self.mock_get_healthcheck)
-
-        # Create a mock Pool
-        pool_data_unchanged = {'monitor': '/mesos/server-app_80',
-                               'balance': 'round-robin'}
-        pool = self.create_mock_pool('server-app_80',
-                                     **pool_data_unchanged)
-
-        # Create mock Pool Members
-        member_data_unchanged = {'state': 'user-up', 'session': 'user-enabled'}
-        member = self.create_mock_pool_member('10.141.141.10:31132',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('10.141.141.10:31615',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('10.141.141.10:31982',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('10.141.141.10:31972',
-                                              **member_data_unchanged)
-
-        # Create a mock Healthcheck
-        health_data_unchanged = {
-            'interval': 20,
-            'timeout': 61,
-            'send': 'GET / HTTP/1.0\\r\\n\\r\\n'
-        }
-        healthcheck = self.create_mock_healthcheck(
-            'server-app_80', **health_data_unchanged)
-
-        # Pool, Member, and Healthcheck are not modified
-        cfg = ctlr.create_config_marathon(self.bigip, apps)
-        self.bigip.regenerate_config_f5(cfg)
-        self.assertFalse(pool.modify.called)
-        self.assertFalse(member.modify.called)
-        self.assertFalse(healthcheck.modify.called)
-
-        # Pool is modified
-        pool_data_changed = {
-            'balance': 'least-connections',
-            'monitor': 'server-app_8080'
-        }
-        for key in pool_data_changed:
-            data = pool_data_unchanged.copy()
-            # Change one thing
-            data[key] = pool_data_changed[key]
-            pool = self.create_mock_pool('server-app_80', **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(pool.modify.called)
-
-        # Member is modified
-        member_data_changed = {
-            'state': 'user-down',
-            'session': 'user-disabled'
-        }
-        for key in member_data_changed:
-            data = member_data_unchanged.copy()
-            # Change one thing
-            data[key] = member_data_changed[key]
-            member = self.create_mock_pool_member('10.141.141.10:31132',
-                                                  **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(member.modify.called)
-
-        # Healthcheck is modified
-        health_data_changed = {
-            'interval': 10,
-            'timeout': 30,
-            'send': 'GET /mypath HTTP/1.0\\r\\n\\r\\n'
-        }
-        for key in health_data_changed:
-            data = health_data_unchanged.copy()
-            # Change one thing
-            data[key] = health_data_changed[key]
-            healthcheck = self.create_mock_healthcheck(
-                'server-app_80', **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(healthcheck.modify.called)
-
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-
-
-class HealthCheckParmsTest(unittest.TestCase):
-    """Tests for validating what is sent to the Big-IP for health monitors."""
-
-    http_keys = ('adaptive',
-                 'adaptiveDivergenceType',
-                 'adaptiveDivergenceValue',
-                 'adaptiveLimit',
-                 'adaptiveSamplingTimespan',
-                 'appService',
-                 'defaultsFrom',
-                 'description',
-                 'destination',
-                 'interval',
-                 'ipDscp',
-                 'manualResume',
-                 'name',
-                 'tmPartition',
-                 'password',
-                 'recv',
-                 'recvDisable',
-                 'reverse',
-                 'send',
-                 'timeUntilUp',
-                 'timeout',
-                 'transparent',
-                 'upInterval',
-                 'username',
-                 )
-    tcp_keys = ('adaptive',
-                'adaptiveDivergenceType',
-                'adaptiveDivergenceValue',
-                'adaptiveLimit',
-                'adaptiveSamplingTimespan',
-                'appService',
-                'defaultsFrom',
-                'description',
-                'destination',
-                'interval',
-                'ipDscp',
-                'manualResume',
-                'name',
-                'tmPartition',
-                'recv',
-                'recvDisable',
-                'reverse',
-                'send',
-                'timeUntilUp',
-                'timeout',
-                'transparent',
-                'upInterval',
-                )
-    tcpHealthData = {}
-    httpHealthData = {}
-    partition = 'hctest'
-    health_monitor = None
-
-    def setUp(self):
-        """Test suite set up."""
-        with patch.object(BigIP, '_get_tmos_version'):
-            self.bigip = CloudBigIP('1.2.3.4', '443', 'admin',
-                                    'default', [self.partition])
-        self.bigip.get_healthcheck = Mock(
-            side_effect=self.mock_get_healthcheck)
-        self.bigip.get_http_healthmonitor = Mock(
-            side_effect=self.mock_get_healthmonitor)
-        self.bigip.get_tcp_healthmonitor = Mock(
-            side_effect=self.mock_get_healthmonitor)
-
-        self.bigip.healthcheck_exists = Mock()
-        self.bigip.healthcheck_exists.return_value = {'http': True,
-                                                      'tcp': True}
-        self.httpHealthData = {
-            'description': 'this one is http',
-            'portIndex': 0,
-            'protocol': 'http',
-            'timeoutSeconds': 20,
-            'interval': 20,
-            'intervalSeconds': 20,
-            'ignoreHttp1xx': False,
-            'gracePeriodSeconds': 5,
-            'send': 'GET / HTTP/1.0\\r\\n\\r\\n',
-            'timeout': 61,
-            'maxConsecutiveFailures': 3,
-            'path': '/',
-            'username': 'admin',
-            'password': 'changeme',
-            }
-        self.tcpHealthData = {
-            'description': 'this one is tcp',
-            'portIndex': 0,
-            'protocol': 'tcp',
-            'timeoutSeconds': 20,
-            'interval': 20,
-            'intervalSeconds': 20,
-            'ignoreHttp1xx': False,
-            'gracePeriodSeconds': 5,
-            'send': None,
-            'timeout': 61,
-            'maxConsecutiveFailures': 3,
-            'path': '/',
-            'username': 'admin',
-            'password': 'changeme',
-            }
-
-    def mock_get_healthmonitor(self):
-        """Map this call to our cached health_monitor."""
-        return self.health_monitor
-
-    def mock_get_healthcheck(self, partition, hc, hc_type):
-        """Map this call to our cached health_monitor."""
-        return self.health_monitor
-
-    def validate_http_data(self, **data):
-        """Make sure only valid http data is present in the dict."""
-        for k in data:
-            self.assertTrue(k in self.http_keys)
-
-    def validate_tcp_data(self, **data):
-        """Make sure only valid tcp data is present in the dict."""
-        for k in data:
-            self.assertTrue(k in self.tcp_keys)
-
-    def mock_healthcheck_create_http(self, partition, **data):
-        """Mock which gets called to actually do the create."""
-        self.validate_http_data(**data)
-
-    def mock_healthcheck_modify_http(self, **data):
-        """Mock which gets called to actually do the modify."""
-        self.validate_http_data(**data)
-
-    def mock_healthcheck_create_tcp(self, partition, **data):
-        """Mock which gets called to actually do the create."""
-        self.validate_tcp_data(**data)
-
-    def mock_healthcheck_modify_tcp(self, **data):
-        """Mock which gets called to actually do the modify."""
-        self.validate_tcp_data(**data)
-
-    def test_healthmonitor_http(self):
-        """Test creating and updating http health monitors."""
-        hc = HealthCheck('http-server')
-        hc.create = Mock(side_effect=self.mock_healthcheck_create_http)
-        hc.modify = Mock(side_effect=self.mock_healthcheck_modify_http)
-        self.health_monitor = hc
-        self.bigip.healthcheck_create(self.partition, self.httpHealthData)
-        self.assertTrue(hc.create.called)
-        self.httpHealthData['description'] = 'this should trigger a modify'
-        self.bigip.healthcheck_update(self.partition, hc, self.httpHealthData)
-        self.assertTrue(hc.modify.called)
-
-    def test_healthmonitor_tcp(self):
-        """Test creating and updating tcp health monitors."""
-        hc = HealthCheck('tcp-server')
-        hc.create = Mock(side_effect=self.mock_healthcheck_create_tcp)
-        hc.modify = Mock(side_effect=self.mock_healthcheck_modify_tcp)
-        self.health_monitor = hc
-        self.bigip.healthcheck_create(self.partition, self.tcpHealthData)
-        self.assertTrue(hc.create.called)
-        self.tcpHealthData['description'] = 'this should trigger a modify'
-        self.bigip.healthcheck_update(self.partition, hc, self.tcpHealthData)
-        self.assertTrue(hc.modify.called)
-
-    def test_healthcheck_update_change_protocol_http(self):
-        """Test updating the protocol for a health monitor from http to tcp."""
-        hc = HealthCheck('http-server')
-        hc.create = Mock(side_effect=self.mock_healthcheck_create_http)
-        hc.modify = Mock()
-        fake_pool = Pool('fake_pool', monitor='test_monitor')
-        self.health_monitor = hc
-        # Mock that the monitor already exists in the http protocol
-        self.bigip.healthcheck_exists.return_value = {'http': True,
-                                                      'tcp': False}
-        self.bigip.healthcheck_create = Mock(
-            wraps=self.bigip.healthcheck_create)
-        self.bigip.monitor_protocol_change = Mock(
-            wraps=self.bigip.monitor_protocol_change)
-        self.bigip.healthcheck_delete = Mock()
-        self.bigip.get_pool = Mock(return_value=fake_pool)
-        # Create the health monitor
-        self.bigip.healthcheck_create(self.partition, self.httpHealthData)
-        self.assertTrue(hc.create.called)
-        hc.create.side_effect = self.mock_healthcheck_create_tcp
-        # Update the health monitor with our new protocol
-        self.bigip.healthcheck_update(self.partition, hc, self.tcpHealthData)
-        self.assertTrue(self.bigip.healthcheck_delete.called)
-        self.assertEqual(self.bigip.healthcheck_create.call_count, 2)
-        self.assertEqual(hc.create.call_count, 2)
-        self.assertFalse(hc.modify.called)
-        # Verify monitor_protocol_change is called with the old protocol
-        self.assertEqual(self.bigip.monitor_protocol_change.call_args[0][3],
-                         'http')
-
-    def test_healthcheck_update_change_protocol_tcp(self):
-        """Test updating the protocol for a health monitor from tcp to http."""
-        hc = HealthCheck('tcp-server')
-        hc.create = Mock(side_effect=self.mock_healthcheck_create_tcp)
-        hc.modify = Mock()
-        fake_pool = Pool('fake_pool', monitor='test_monitor')
-        self.health_monitor = hc
-        # Mock that the monitor already exists in the tcp protocol
-        self.bigip.healthcheck_exists.return_value = {'http': False,
-                                                      'tcp': True}
-        self.bigip.healthcheck_create = Mock(
-            wraps=self.bigip.healthcheck_create)
-        self.bigip.monitor_protocol_change = Mock(
-            wraps=self.bigip.monitor_protocol_change)
-        self.bigip.healthcheck_delete = Mock()
-        self.bigip.get_pool = Mock(return_value=fake_pool)
-        # Create the health monitor
-        self.bigip.healthcheck_create(self.partition, self.tcpHealthData)
-        self.assertTrue(hc.create.called)
-        hc.create.side_effect = self.mock_healthcheck_create_http
-        # Update the health monitor with our new protocol
-        self.bigip.healthcheck_update(self.partition, hc, self.httpHealthData)
-        self.assertTrue(self.bigip.healthcheck_delete.called)
-        self.assertEqual(self.bigip.healthcheck_create.call_count, 2)
-        self.assertEqual(hc.create.call_count, 2)
-        self.assertFalse(hc.modify.called)
-        # Verify monitor_protocol_change is called with the old protocol
-        self.assertEqual(self.bigip.monitor_protocol_change.call_args[0][3],
-                         'tcp')
+        # Corrupt the config
+        del cfg['virtualServers'][0]['name']
+        self.assertRaises(F5CcclValidationError, self.cccl.apply_config, cfg)
 
 
 class GetProtocolTest(unittest.TestCase):
@@ -2822,84 +1354,15 @@ class GetProtocolTest(unittest.TestCase):
         exp_res = ['tcp', 'tcp', 'udp', 'tcp', 'tcp', 'udp', 'tcp', 'tcp',
                    'udp']
         for i in range(0, len(valid)):
-            res = get_protocol(valid[i])
+            res = ctlr.get_protocol(valid[i])
             self.assertEqual(res, exp_res[i])
 
     def test_get_protocol_invalid_input(self):
         """Test get_protocol with invalid input."""
         invalid = ['abc', 'ABC', 'aBc', '', ' ', True, 1, [], {}]
         for i in range(0, len(invalid)):
-            res = get_protocol(invalid[i])
+            res = ctlr.get_protocol(invalid[i])
             self.assertEqual(res, None)
-
-
-class VirtualUpdateTest(unittest.TestCase):
-    """Test CCCL virtual_update function."""
-
-    class MockVirtual():
-        """Mock virtual class."""
-
-        def __init__(self, destination, data):
-            """Initialize a MockVirtual object."""
-            self.destination = destination
-            self.data = data
-
-        def modify(self, **kwargs):
-            """Mocked modify function."""
-            pass
-
-    def mock_get_virtual(self, partition, virtual):
-        """Returns the mocked virtual passed to it."""
-        return virtual
-
-    def mock_get_virtual_profiles(self, virtual):
-        """Returns list of mocked virtual profiles."""
-        profiles = []
-        for profile in virtual.data['profiles']:
-            if profile['name'] == 'http':
-                profiles.append({'partition': profile['partition'],
-                                 'name': 'tcp'})
-            profiles.append(profile)
-        return profiles
-
-    def setUp(self):
-        """Test suite set up."""
-        # Mock the call to _get_tmos_version(), which tries to make a
-        # connection
-        self.partition = 'test'
-        self.ipAddr = '1.2.3.4'
-        with patch.object(BigIP, '_get_tmos_version'):
-            self.bigip = CloudBigIP(self.ipAddr, '443', 'admin',
-                                    'default', [self.partition])
-
-        # Mock out SDK function calls
-        self.bigip.get_virtual_address = Mock(return_value=self.ipAddr)
-        self.bigip.virtual_address_update = Mock()
-        self.bigip.get_virtual = Mock(side_effect=self.mock_get_virtual)
-        self.bigip.get_virtual_profiles = \
-            Mock(side_effect=self.mock_get_virtual_profiles)
-        self.virtual_address_delete = Mock()
-        self.MockVirtual.modify = Mock()
-
-    def test_virtual_update_inherited_profile_no_update(self):
-        """Test virtual_update with inherited tcp profiles."""
-        destination = '/mockpath/' + self.ipAddr + ':8080'
-        data = {
-                    'virtual': {
-                        'destination': destination,
-                        'profiles': [
-                            {'partition': self.partition, 'name': 'http'}
-                        ]
-                    },
-                    'virtual_address': self.ipAddr
-                }
-        virtual = self.MockVirtual(destination, data['virtual'])
-
-        # Verify that the virtual server is not updated since the inherited tcp
-        # profiles should be removed preventing a mismatch in data profiles and
-        # the profiles returned from the BIG-IP.
-        self.bigip.virtual_update(self.partition, virtual, data)
-        self.assertFalse(self.MockVirtual.modify.called)
 
 
 class IsLabelDataValidTest(unittest.TestCase):
@@ -2915,12 +1378,6 @@ class IsLabelDataValidTest(unittest.TestCase):
             self.servicePort = port
             self.bindAddr = addr
             self.balance = balance
-
-    def setUp(self):
-        """Test suite set up."""
-        with patch.object(BigIP, '_get_tmos_version'):
-            self.bigip = CloudBigIP('1.2.3.4', '443', 'admin',
-                                    'default', ['test'])
 
     def test_is_label_data_valid_valid_input(self):
         """Test is_label_data_valid with valid input."""
@@ -2948,19 +1405,19 @@ class IsLabelDataValidTest(unittest.TestCase):
                    'ratio-session']
         for i in range(0, len(proto)):
             app = self.MockAppLabelData(proto[i], port[0], addr[0], balance[0])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertTrue(res)
         for i in range(0, len(port)):
             app = self.MockAppLabelData(proto[0], port[i], addr[0], balance[0])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertTrue(res)
         for i in range(0, len(addr)):
             app = self.MockAppLabelData(proto[0], port[0], addr[i], balance[0])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertTrue(res)
         for i in range(0, len(balance)):
             app = self.MockAppLabelData(proto[0], port[0], addr[0], balance[i])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertTrue(res)
 
     def test_is_label_data_valid_invalid_input(self):
@@ -2973,19 +1430,19 @@ class IsLabelDataValidTest(unittest.TestCase):
         balance = ['string', '', ' ', 123, False, [], {}]
         for i in range(0, len(proto)):
             app = self.MockAppLabelData(proto[i], port[0], addr[0], balance[0])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
         for i in range(0, len(port)):
             app = self.MockAppLabelData(proto[0], port[i], addr[0], balance[0])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
         for i in range(0, len(addr)):
             app = self.MockAppLabelData(proto[0], port[0], addr[i], balance[0])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
         for i in range(0, len(balance)):
             app = self.MockAppLabelData(proto[0], port[0], addr[0], balance[i])
-            res = self.bigip.is_label_data_valid(app)
+            res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
 
 


### PR DESCRIPTION
Changes to the marathon-bigip-ctlr:
- Creation of a CCCL instance for each managed partition
- Removed wildcard partition argument
- Modification of method create_config_marathon() to create a service
  description consistent with the CCCL schema
- Support multiple monitors for pools
- Conversion of unit tests to focus on Marathon-specific functions
  and defer unit testing of BIG-IP resources to CCCL
- Moved common.py from the CCCL repo to this repo because it mostly contained
  Marathon-specific functions
- Configuration of root logger to properly log CCCL messages

Status:
- All unit tests PASS
- All functional tests PASS