### PR TITLE
travis able to publish docs to aws

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,15 @@ script:
       "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
     fi
   - |
-    if [ "$TRAVIS_TAG" == "1.0-stable" ]; then
-      docker run -it f5devcentral/containthedocs publish-product-docs-to-prod connectors/marathon-bigip-ctlr v1.0
-    fi
-  - |
     if [ "$TRAVIS_REPO_SLUG" == "F5Networks/k8s-bigip-ctlr" -o "$COVERALLS_REPO_TOKEN" ]; then
       ./build-tools/run-in-docker.sh coveralls
     fi
+
+deploy:
+  - provider: script
+    skip_cleanup: true
+    on:
+      branch: 1.1-stable
+      repo: F5Networks/marathon-bigip-ctlr
+    script:
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/marathon-bigip-ctlr v1.1

--- a/build-tools/deploy-docs.sh
+++ b/build-tools/deploy-docs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Don't set -x
+# we need to keep the secrets AWS variables out of the logs
+
+exec docker run --rm -it -v $PWD:$PWD --workdir $PWD -e  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET=$AWS_S3_BUCKET f5devcentral/containthedocs "$@"

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,7 +1,7 @@
 Release Notes for Marathon BIG-IP Controller
 ============================================
 
-v1.1.0-dev
+|release|
 ----------
 
 Added Functionality
@@ -37,4 +37,3 @@ Limitations
 * The deployment of the controller will fail if the BIG-IP is not available when the controller starts.
 * Parameters other than IPAddress and Port (e.g. Connection Limit) specified in the iApp Pool Member Table apply to all members of the pool.
 * Health monitor timeout is not described in documentation
-


### PR DESCRIPTION
Problem:
- travis-ci lacked ability to push docs to aws for release

Solution:
- added deploy section to .travis.yml
- added deploy-docs.sh