### PR TITLE
add slack build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,8 @@ deploy:
       repo: F5Networks/marathon-bigip-ctlr
     script:
       - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/marathon-bigip-ctlr v1.1
+
+notifications:
+  slack:
+    rooms:
+      secure: BbX9rEy7iR/QpN5lOFIpDLX61LcCoi2czfVMGi+msax5JmxmreKhZazRYnvr1gZAIUekgSPYnZwyyP56FFpLADQxXBhEWHSM3Wpkz5mfsoHJxiZxWXUB6lvvXX3BoCgyVafVwTReQxR5xByw2YUKbrnKZ5+10ohp6ElVvqQifi0urNbwfIW/Ff/rlp0cOg+BRpE/qacvyWGfNKrBeXxNK+AM1dN3/MX4NcOjwd4N2/PMvOppI9ZYebFzgUn3ICpdixAR1i/No/QhcE5GnplG5EKp/vNkE9LZXnCHFVQGTkU2M+2a5U9akNVVw5V6eu7NFXnDt1REpdKXRlCmJbVCCuPkdxB0Bl0oQwFbI03gXJY7zCkwsf+V6DM9mfezXjDO0q+vVmttbQyDHXx9SefFpfj/jIwwoksna0Wl/RlMsFKzrtapDrB/XDe/uJPk6vHGGyiQBcFnwwweE5VxTGL0dHkYTAZg4GBcleTKUQo8dpfQajBjEEd5IeWc4StogFHmANzV3PxKPKsEZzFT6drOASZisAG6P78SDY5a+AEPf9m8eWvQeksZRx26pLL3QtHUt92J9HbnrnfNgSxCYYogWDg0HPQdQpuv7HysrtFtRBT4tmmEVrWOITo1g3auX1Ho+XUxgOqKHV+fmzhsA2NkUypPk+8jJOMnMbkBNdgKJbo=


### PR DESCRIPTION
Problem:
Travis builds did not post to repo slack channel.

Analysis:
Notifications are configured for the F5Networks namespace, meaning that pushes to branches on a pull request will send notifications, but pushes to branches pre-pull request will not. Notifications are sent on success as well as failure since there is not a "merge when build succeeds" as in GitLab.

Solution:
Generated "secure" key using travis cli tool and added notifiaction section to `.travis.yml` to post build notices to repo slack channel.

fixes #177