### PR TITLE
Change product name per new guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Build Status](https://travis-ci.org/F5Networks/marathon-bigip-ctlr.svg?branch=master)](https://travis-ci.org/F5Networks/marathon-bigip-ctlr) [![Coverage Status](https://coveralls.io/repos/github/F5Networks/marathon-bigip-ctlr/badge.svg?branch=HEAD)](https://coveralls.io/github/F5Networks/marathon-bigip-ctlr?branch=HEAD)
 
-F5 Marathon BIG-IP Controller
-=============================
+F5 BIG-IP Controller for Marathon
+=================================
 
-The F5 Marathon BIG-IP Controller makes F5 BIG-IP
+The F5 BIG-IP Controller for Marathon makes F5 BIG-IP
 [Local Traffic Manager](https://f5.com/products/big-ip/local-traffic-manager-ltm)
 services available for applications defined in a
 [Marathon](https://mesosphere.github.io/marathon/) environment.
@@ -12,7 +12,8 @@ Documentation
 -------------
 
 For instruction on how to use this component, see the
-[F5 Marathon BIG-IP Controller docs](http://clouddocs.f5.com/products/connectors/marathon-bigip-ctlr/latest/).
+[docs](http://clouddocs.f5.com/products/connectors/marathon-bigip-ctlr/latest/) for
+F5 BIG-IP Controller for Marathon.
 
 For guides on this and other solutions for Marathon, see the
 [F5 Marathon Solution Guides](http://clouddocs.f5.com/containers/latest/marathon).

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,5 +1,5 @@
-F5 Marathon BIG-IP Controller
-=============================
+F5 BIG-IP Controller for Marathon
+=================================
 
 .. toctree::
     :hidden:
@@ -8,7 +8,7 @@ F5 Marathon BIG-IP Controller
     RELEASE-NOTES
     /_static/ATTRIBUTIONS
 
-The F5 Marathon BIG-IP Controller is a `Marathon Application`_ that manages F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) services.
+The |project| is a `Marathon Application`_ that manages F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) services.
 
 |release-notes|
 
@@ -33,7 +33,7 @@ See the `F5 Marathon Container Connector user documentation </containers/v1/mara
 Overview
 --------
 
-The F5 Marathon BIG-IP Controller is a Docker container that runs as a `Marathon Application`_. It watches the Marathon API for the creation/destruction of Marathon Apps; when it discovers an App with the F5 labels applied, it automatically updates the BIG-IP as follows:
+The |project| is a Docker container that runs as a `Marathon Application`_. It watches the Marathon API for the creation/destruction of Marathon Apps; when it discovers an App with the F5 labels applied, it automatically updates the BIG-IP as follows:
 
 - matches the Marathon App to the specified BIG-IP partition;
 - creates a virtual server and pool for each `port-mapping <https://mesosphere.github.io/marathon/docs/ports.html>`_ ;
@@ -97,7 +97,7 @@ F5 application labels are key-value pairs that correspond to BIG-IP configuratio
 To configure virtual servers on the BIG-IP for specific application service ports, define a port index in the configuration parameter.
 In the table below, ``{n}`` refers to an index into the service-port mapping array, starting at 0.
 
-F5 Marathon BIG-IP Controller supports two BIG-IP configuration modes (normal and iApp), with a different set of application labels for each mode. Normal mode directly configures the virtual servers via the application labels, whereas iApp mode configures virtual servers via an iApp template.
+|project| supports two BIG-IP configuration modes (normal and iApp), with a different set of application labels for each mode. Normal mode directly configures the virtual servers via the application labels, whereas iApp mode configures virtual servers via an iApp template.
 
 
 Application Labels for Normal Mode
@@ -289,7 +289,7 @@ Example Configuration Files
 Usage Example
 -------------
 
-The F5 Marathon BIG-IP Controller configures objects on the BIG-IP in response to Marathon Applications and Tasks. For our example App -- `sample-marathon-application.json <./_static/config_examples/sample-marathon-application.json>`_ -- starting the F5 Marathon BIG-IP Controller with the following JSON in Marathon creates objects in the ``/mesos`` partition on the BIG-IP.
+The |project| configures objects on the BIG-IP in response to Marathon Applications and Tasks. For our example App -- `sample-marathon-application.json <./_static/config_examples/sample-marathon-application.json>`_ -- starting the |project| with the following JSON in Marathon creates objects in the ``/mesos`` partition on the BIG-IP.
 
 ::
 

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,5 +1,5 @@
-Release Notes for Marathon BIG-IP Controller
-============================================
+Release Notes for F5 BIG-IP Controller for Marathon
+===================================================
 
 |release|
 ----------
@@ -34,7 +34,7 @@ Added Functionality
 Limitations
 ^^^^^^^^^^^
 * Command line parameter alternatives to the environment variables are not documented in the user guide.
-* Cannot share endpoints managed in the partition controlled by the Marathon BIG-IP Controller with endpoints managed in another partition.
+* Cannot share endpoints managed in the partition controlled by the |project| with endpoints managed in another partition.
 * iApp and virtual server parameters are not treated as being mutually exclusive. You should not specify both, otherwise the BIG-IP may be improperly configured.
 * The deployment of the controller will fail if the BIG-IP is not available when the controller starts.
 * Parameters other than IPAddress and Port (e.g. Connection Limit) specified in the iApp Pool Member Table apply to all members of the pool.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ source_parsers = {
 master_doc = 'index'
 
 # General information about the project.
-project = u'F5 Marathon BIG-IP Controller'
+project = u'F5 BIG-IP Controller for Marathon'
 copyright = u'2016,2017 F5 Networks Inc'
 author = u'F5 Networks'
 


### PR DESCRIPTION
Problem:
Product names were not meeting F5 guidelines.

Solution:
Changed product name references in all documentation per guidelines
using templates when available.