### PR TITLE
Fix improper substitution for "|project|"

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -8,7 +8,7 @@ F5 BIG-IP Controller for Marathon
     RELEASE-NOTES
     /_static/ATTRIBUTIONS
 
-The |project| is a `Marathon Application`_ that manages F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) services.
+The |mctlr-long| is a `Marathon Application`_ that manages F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) services.
 
 |release-notes|
 
@@ -33,7 +33,7 @@ See the `F5 Marathon Container Connector user documentation </containers/v1/mara
 Overview
 --------
 
-The |project| is a Docker container that runs as a `Marathon Application`_. It watches the Marathon API for the creation/destruction of Marathon Apps; when it discovers an App with the F5 labels applied, it automatically updates the BIG-IP as follows:
+The |mctlr-long| is a Docker container that runs as a `Marathon Application`_. It watches the Marathon API for the creation/destruction of Marathon Apps; when it discovers an App with the F5 labels applied, it automatically updates the BIG-IP as follows:
 
 - matches the Marathon App to the specified BIG-IP partition;
 - creates a virtual server and pool for each `port-mapping <https://mesosphere.github.io/marathon/docs/ports.html>`_ ;
@@ -97,7 +97,7 @@ F5 application labels are key-value pairs that correspond to BIG-IP configuratio
 To configure virtual servers on the BIG-IP for specific application service ports, define a port index in the configuration parameter.
 In the table below, ``{n}`` refers to an index into the service-port mapping array, starting at 0.
 
-|project| supports two BIG-IP configuration modes (normal and iApp), with a different set of application labels for each mode. Normal mode directly configures the virtual servers via the application labels, whereas iApp mode configures virtual servers via an iApp template.
+|mctlr-long| supports two BIG-IP configuration modes (normal and iApp), with a different set of application labels for each mode. Normal mode directly configures the virtual servers via the application labels, whereas iApp mode configures virtual servers via an iApp template.
 
 
 Application Labels for Normal Mode
@@ -289,7 +289,7 @@ Example Configuration Files
 Usage Example
 -------------
 
-The |project| configures objects on the BIG-IP in response to Marathon Applications and Tasks. For our example App -- `sample-marathon-application.json <./_static/config_examples/sample-marathon-application.json>`_ -- starting the |project| with the following JSON in Marathon creates objects in the ``/mesos`` partition on the BIG-IP.
+The |mctlr-long| configures objects on the BIG-IP in response to Marathon Applications and Tasks. For our example App -- `sample-marathon-application.json <./_static/config_examples/sample-marathon-application.json>`_ -- starting the |mctlr-long| with the following JSON in Marathon creates objects in the ``/mesos`` partition on the BIG-IP.
 
 ::
 

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -34,7 +34,7 @@ Added Functionality
 Limitations
 ^^^^^^^^^^^
 * Command line parameter alternatives to the environment variables are not documented in the user guide.
-* Cannot share endpoints managed in the partition controlled by the |project| with endpoints managed in another partition.
+* Cannot share endpoints managed in the partition controlled by the |mctlr-long| with endpoints managed in another partition.
 * iApp and virtual server parameters are not treated as being mutually exclusive. You should not specify both, otherwise the BIG-IP may be improperly configured.
 * The deployment of the controller will fail if the BIG-IP is not available when the controller starts.
 * Parameters other than IPAddress and Port (e.g. Connection Limit) specified in the iApp Pool Member Table apply to all members of the pool.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,8 @@ rst_epilog = '''
 .. |attributions| raw:: html
 
     <a href="http://clouddocs.f5.com/products/connectors/marathon-bigip-ctlr/%(url_version)s/_static/ATTRIBUTIONS.html">Attributions</a>
+.. |mctlr| replace:: :code:`marathon-bigip-ctlr`
+.. |mctlr-long| replace:: F5 BIG-IP Controller for Marathon
 ''' % {
     'url_version': version
 }


### PR DESCRIPTION
Problem:
The docs build emits the following warnings and the resulting html
docs don't have the proper substitution for |project|:
WARNING: Undefined substitution referenced: "project".

Solution:
Per the Sphinx docs, |project| is not available as a substitution.
Added explicit variables with the short and long name for the product
and used these where needed.