### PR TITLE
Issue-211: Service Ports don't exist for DC/OS Virtual Networks

### DIFF
--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -577,10 +577,17 @@ def get_apps(apps, health_check):
                 marathon_app.app['labels']['F5_PARTITION']
         marathon_apps.append(marathon_app)
 
-        service_ports = app['ports']
-        logger.debug("Application service ports = %s", (repr(service_ports)))
-        logger.debug("Labels for app %s: %s", app['id'],
-                     marathon_app.app['labels'])
+        # Address nonexistent 'ports' for application when DC/OS Virtual
+        # Networking is used.
+        try:
+            service_ports = app['ports']
+            logger.debug("Application service ports = %s",
+                         (repr(service_ports)))
+            logger.debug("Labels for app %s: %s", app['id'],
+                         marathon_app.app['labels'])
+        except Exception:
+            service_ports = {}
+            logger.warning("Warning, no service ports found for " + appId)
 
         for i, servicePort in enumerate(service_ports):
             try:

--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -577,6 +577,9 @@ def get_apps(apps, health_check):
                 marathon_app.app['labels']['F5_PARTITION']
         marathon_apps.append(marathon_app)
 
+
+        del app['ports']
+
         # Address nonexistent 'ports' for application when DC/OS Virtual
         # Networking is used.
         try:
@@ -585,7 +588,7 @@ def get_apps(apps, health_check):
                          (repr(service_ports)))
             logger.debug("Labels for app %s: %s", app['id'],
                          marathon_app.app['labels'])
-        except Exception:
+        except KeyError:
             service_ports = {}
             logger.warning("Warning, no service ports found for " + appId)
 


### PR DESCRIPTION
Service ports don't exist for Marathon apps when DC/OS Virtual
Networks are in use. Gracefully handle the case when an app has no
service ports.