### PR TITLE
Add docker latest tag and docker label to allow pinned image for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
     fi
   - export IMG_TAG="${BASE_PUSH_TARGET}:${TRAVIS_COMMIT}"
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
+  - export BUILD_STAMP=devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID-$(date +%s)
   - export COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
   - export CTLR_VERSION=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
   - ./build-tools/build-devel-image.sh
@@ -30,8 +31,11 @@ script:
     if [ "$DOCKER_READY" ]; then
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
-      docker push "$BASE_PUSH_TARGET"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$BUILD_STAMP"
+      docker push "$IMG_TAG"
+      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+      docker push "$BASE_PUSH_TARGET:$BUILD_STAMP"
+      docker push "$BASE_PUSH_TARGET:latest"
     fi
   - |
     if [ "$TRAVIS_REPO_SLUG" == "F5Networks/k8s-bigip-ctlr" -o "$COVERALLS_REPO_TOKEN" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,12 @@ script:
   - ./build-tools/build-devel-image.sh
   - ./build-tools/run-in-docker.sh make python-sanity
   - ./build-tools/build-runtime-images.sh
-  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
   - |
     if [ "$DOCKER_READY" ]; then
-      docker push "$IMG_TAG"
-      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker push \
-      "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+      docker push "$BASE_PUSH_TARGET"
     fi
   - |
     if [ "$TRAVIS_REPO_SLUG" == "F5Networks/k8s-bigip-ctlr" -o "$COVERALLS_REPO_TOKEN" ]; then

--- a/build-tools/build-runtime-images.sh
+++ b/build-tools/build-runtime-images.sh
@@ -19,6 +19,7 @@ ls -la $WKDIR
 
 docker build --force-rm ${NO_CACHE_ARGS} \
   -t $IMG_TAG \
+  --label BUILD_STAMP=$BUILD_STAMP \
   -f $WKDIR/Dockerfile.runtime \
   $WKDIR
 


### PR DESCRIPTION
Problem:
- Dockerhub images did not have "latest" tag
- images need to be able to be specifically referenced in automated regression tests

Solution:
- Updated tagging to included latest
- Added timestamp to build tag and included that information as a docker label to make it available to docker inspect in regression set up.