### PR TITLE
Remove f5-sdk dependency from Marathon ctlr

### DIFF
--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -52,9 +52,9 @@ from sseclient import SSEClient
 
 from common import (set_logging_args, set_marathon_auth_args,
                     setup_logging, get_marathon_auth_params, resolve_ip)
-from f5.bigip import ManagementRoot
 from f5_cccl.api import F5CloudServiceManager
 from f5_cccl.exceptions import F5CcclError
+from f5_cccl.utils.mgmt import mgmt_root
 
 
 # BIG-IP load-balancing methods
@@ -1142,12 +1142,12 @@ if __name__ == '__main__':
     setup_logging(logging.getLogger(), args.log_format, args.log_level)
 
     # BIG-IP to manage
-    bigip = ManagementRoot(
+    bigip = mgmt_root(
         args.host,
         args.username,
         args.password,
-        port=args.port,
-        token="tmos")
+        args.port,
+        "tmos")
 
     # Management for the BIG-IP partitions
     cccls = []
@@ -1155,8 +1155,7 @@ if __name__ == '__main__':
         cccl = F5CloudServiceManager(
             bigip,
             partition,
-            prefix="",
-            schema_path="./src/f5-cccl/f5_cccl/schemas/cccl-api-schema.yml")
+            prefix="")
         cccls.append(cccl)
 
     # Set request retries

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@6c59f69f2e24529d2e009c609982bc9d9662d4de#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@4c0a4fc9b15ef0adacdd45bdaf789ddfdbb68f5c#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,6 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@6c59f69f2e24529d2e009c609982bc9d9662d4de#egg=f5-cccl
-f5-icontrol-rest==1.3.0
-f5-sdk==2.2.2
+-e git+https://github.com/f5devcentral/f5-cccl.git@4c0a4fc9b15ef0adacdd45bdaf789ddfdbb68f5c#egg=f5-cccl
 requests==2.9.1
 sseclient==0.0.14
 configargparse==0.10.0

--- a/tests/test.py
+++ b/tests/test.py
@@ -28,15 +28,14 @@ import copy
 import time
 from sseclient import Event
 from mock import Mock, mock_open, patch
-from f5_cccl.common import DCOSAuth, get_marathon_auth_params, setup_logging
-from f5.bigip import ManagementRoot
+from common import DCOSAuth, get_marathon_auth_params, setup_logging
+from f5_cccl.utils.mgmt import ManagementRoot
+from f5_cccl.utils.mgmt import mgmt_root
 from f5_cccl.api import F5CloudServiceManager
 from f5_cccl.exceptions import F5CcclValidationError
 from f5_cccl.exceptions import F5CcclSchemaError
 from StringIO import StringIO
 ctlr = __import__('marathon-bigip-ctlr')
-
-schema_path = "/src/f5-cccl/f5_cccl/schemas/cccl-api-schema.yml"
 
 # Marathon app data
 marathon_test_data = [
@@ -658,17 +657,16 @@ class MarathonTest(unittest.TestCase):
         # Mock the call to _get_tmos_version(), which tries to make a
         # connection
         with patch.object(ManagementRoot, '_get_tmos_version'):
-            bigip = ManagementRoot(
+            bigip = mgmt_root(
                 '1.2.3.4',
                 'admin',
                 'admin',
-                port=443,
-                token='tmos')
+                443,
+                'tmos')
             self.cccl = F5CloudServiceManager(
                 bigip,
                 'mesos',
-                prefix='',
-                schema_path=schema_path)
+                prefix='')
         self.cccl._service_manager._service_deployer._bigip.refresh = Mock()
         self.cccl._service_manager._service_deployer.deploy = \
             Mock(return_value=0)
@@ -766,17 +764,16 @@ class MarathonTest(unittest.TestCase):
         # times the virtual-server name is found
         for partition in partitions:
             with patch.object(ManagementRoot, '_get_tmos_version'):
-                bigip = ManagementRoot(
+                bigip = mgmt_root(
                     '1.2.3.4',
                     'admin',
                     'default',
-                    port=443,
-                    token='tmos')
+                    443,
+                    'tmos')
                 cccl = F5CloudServiceManager(
                     bigip,
                     partition,
-                    prefix='',
-                    schema_path=schema_path)
+                    prefix='')
 
                 cfg = ctlr.create_config_marathon(cccl, apps)
                 if len(cfg['virtualServers']) > 0:
@@ -1313,12 +1310,12 @@ class MarathonTest(unittest.TestCase):
     def test_cccl_exceptions(self, cloud_state='tests/marathon_one_app.json'):
         """Test: CCCL exceptions."""
         with patch.object(ManagementRoot, '_get_tmos_version'):
-            bigip = ManagementRoot(
+            bigip = mgmt_root(
                 '1.2.3.4',
                 'admin',
                 'default',
-                port=443,
-                token='tmos')
+                443,
+                'tmos')
             self.assertRaises(F5CcclSchemaError, F5CloudServiceManager,
                               bigip,
                               'test',


### PR DESCRIPTION
Moved code that configures vxlan tunnels and custom profiles via the f5-sdk
to CCCL and removed the dependency upon the f5-sdk and f5-icontrol-rest.