### PR TITLE
License info for urlib3 and chardet

### DIFF
--- a/.f5license
+++ b/.f5license
@@ -653,3 +653,13 @@
   license: MIT
   author:
     name: Bob Ippolito
+
+# The urllib3 module has an MIT license
+- name: urllib3
+  version: 1.13.1
+  license: MIT
+
+# The chardet module has an LGPL v2.1 license
+- name: chardet
+  version: 2.3.0
+  license: LGPL v2.1


### PR DESCRIPTION
The urllib3 and chardet packages were bundled inside of requests and were
not attributed correctly. Properly attribute the licenses for these packages.