### PR TITLE
Added non-0 route domain support

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -117,7 +117,7 @@ Use the following application labels to deploy virtual servers on the BIG-IP.
 |                       |           |           |               | objects; cannot be "Common"               |                                   |
 +-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------+
 | \F5_{n}_BIND_ADDR     | string    | Optional  | n/a           | IP address of the App service             |                                   |
-|                       |           |           |               |                                           |                                   |
+| [#ba]_                |           |           |               |                                           |                                   |
 |                       |           |           |               | Example:                                  |                                   |
 |                       |           |           |               |                                           |                                   |
 |                       |           |           |               | ``"F5_0_BIND_ADDR": "10.0.0.42"``         |                                   |
@@ -163,6 +163,7 @@ Use the following application labels to deploy virtual servers on the BIG-IP.
 |                       |           |           |               | ``"F5_0_SSL_PROFILE": "Common/clientssl"``|                                   |
 |                       |           |           |               |                                           |                                   |
 +-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------+
+.. [#ba] The controller supports BIG-IP `route domain`_ specific addresses.
 
 You can set the ``F5_{n}_BIND_ADDR`` label via an IPAM system. You can configure your IPAM system to set this label with a chosen IP address, and the controller
 will configure the BIG-IP virtual server when it sees a valid ``F5_{n}_BIND_ADDR``. Virtual server deployment requires the ``F5_{n}_BIND_ADDR`` label, but it is not
@@ -332,3 +333,4 @@ Run the command below on the BIG-IP to view the newly-created objects.
 .. _Identity and Access Management API: https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/iam-api/
 .. _Marathon: https://mesosphere.github.io/marathon/
 .. _Marathon Application: https://mesosphere.github.io/marathon/docs/application-basics.html
+.. _route domain: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/9.html

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,7 +12,12 @@ Added Functionality
 * Can use local and non-local BIG-IP users.
 * Supports multiple BIG-IP health monitors for each Marathon application Service Port.
 * Wildcard (*) for F5_CC_PARTITIONS Configuration Parameter is no longer supported.
+* Support for BIG-IP partitions with non-zero default route domains.
 
+Limitations
+^^^^^^^^^^^
+* You cannot change the default route domain for a partition managed by an F5 controller after the controller has deployed. To specify a new default route domain, use a different partition.
+  
 v1.0.0
 ------
 

--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -32,7 +32,6 @@ marathon-bigip-ctlr just needs to know where to find Marathon.
 
 from __future__ import print_function
 
-import ipaddress
 import json
 import logging
 from operator import attrgetter
@@ -51,7 +50,8 @@ from requests.exceptions import ConnectionError
 from sseclient import SSEClient
 
 from common import (set_logging_args, set_marathon_auth_args,
-                    setup_logging, get_marathon_auth_params, resolve_ip)
+                    setup_logging, get_marathon_auth_params, resolve_ip,
+                    validate_bigip_address)
 from f5_cccl.api import F5CloudServiceManager
 from f5_cccl.exceptions import F5CcclError
 from f5_cccl.utils.mgmt import mgmt_root
@@ -99,7 +99,7 @@ class InvalidServiceDefinitionError(ValueError):
 def set_bindAddr(x, v):
     """App label callback.
 
-    Setthe Virtual Server address from label F5_n_BIND_ADDR
+    Set the Virtual Server address from label F5_n_BIND_ADDR
     """
     x.bindAddr = v
 
@@ -343,9 +343,7 @@ def is_label_data_valid(app):
 
     # Validate address
     if app.bindAddr is not None:
-        try:
-            ipaddress.ip_address(app.bindAddr)
-        except ValueError:
+        if not validate_bigip_address(app.bindAddr):
             logger.error(msg.format('F5_BIND_ADDR', app.appId, app.bindAddr))
             is_valid = False
 

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@4c0a4fc9b15ef0adacdd45bdaf789ddfdbb68f5c#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5edac6c7be8fb105cc3394d846949c329f5b829d#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@4c0a4fc9b15ef0adacdd45bdaf789ddfdbb68f5c#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5edac6c7be8fb105cc3394d846949c329f5b829d#egg=f5-cccl
 requests==2.9.1
 sseclient==0.0.14
 configargparse==0.10.0

--- a/tests/test.py
+++ b/tests/test.py
@@ -1379,7 +1379,8 @@ class IsLabelDataValidTest(unittest.TestCase):
         """Test is_label_data_valid with valid input."""
         proto = ['tcp', 'http', 'udp']
         port = [1, 10000, 65535]
-        addr = [unicode('192.168.0.1'), unicode('2001:db8::')]
+        addr = [unicode('192.168.0.1'), unicode('2001:db8::'),
+                unicode('192.168.0.1%24'), unicode('2001:db8::%0')]
         balance = ['dynamic-ratio-member',
                    'least-connections-member',
                    'observed-node',
@@ -1418,26 +1419,34 @@ class IsLabelDataValidTest(unittest.TestCase):
 
     def test_is_label_data_valid_invalid_input(self):
         """Test is_label_data_valid with invalid input."""
+        valid_proto = 'tcp'
         proto = ['abc', 'ABC', 'abc', '', ' ', 1, False, [], {}]
+        valid_port = 8000
         port = [0, -10000, 65536, '123', '', False, [], {}]
+        valid_addr = unicode('192.168.0.1')
         addr = [unicode('258.0.0.1'), unicode('2001:dg8::1'),
                 unicode('string'), unicode(''), unicode(' '), 'string', True,
-                [], {}]
+                [], {}, unicode('1.1.1.1%cow'), unicode('1.1.1.1%')]
+        valid_balance = 'round-robin'
         balance = ['string', '', ' ', 123, False, [], {}]
         for i in range(0, len(proto)):
-            app = self.MockAppLabelData(proto[i], port[0], addr[0], balance[0])
+            app = self.MockAppLabelData(proto[i], valid_port,
+                                        valid_addr, valid_balance)
             res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
         for i in range(0, len(port)):
-            app = self.MockAppLabelData(proto[0], port[i], addr[0], balance[0])
+            app = self.MockAppLabelData(valid_proto, port[i],
+                                        valid_addr, valid_balance)
             res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
         for i in range(0, len(addr)):
-            app = self.MockAppLabelData(proto[0], port[0], addr[i], balance[0])
+            app = self.MockAppLabelData(valid_proto, valid_port,
+                                        addr[i], valid_balance)
             res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
         for i in range(0, len(balance)):
-            app = self.MockAppLabelData(proto[0], port[0], addr[0], balance[i])
+            app = self.MockAppLabelData(valid_proto, valid_port,
+                                        valid_addr, balance[i])
             res = ctlr.is_label_data_valid(app)
             self.assertFalse(res)
 


### PR DESCRIPTION
Problem:  The BIND_ADDR label currently cannot support route domains.
Solution: Updating the valid input for BIND_ADDR to accept an optional route domain ID.