### PR TITLE
Update to latest CCCL API

### DIFF
--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -925,7 +925,7 @@ class MarathonEventProcessor(object):
                     for cccl in self.__cccls:
                         cfg = create_config_marathon(cccl, self.__apps)
                         try:
-                            incomplete += cccl.apply_config(cfg)
+                            incomplete += cccl.apply_ltm_config(cfg)
                         except F5CcclError as e:
                             logger.error("CCCL Error: %s", e.msg)
 

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@dd2ef5aa93175e41f64c4f95ba6bc5d714237f44#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@9bd8f2668d48e28c7fdc848b5ab0ab06a37e68e1#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@dd2ef5aa93175e41f64c4f95ba6bc5d714237f44#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@9bd8f2668d48e28c7fdc848b5ab0ab06a37e68e1#egg=f5-cccl
 requests==2.9.1
 sseclient==0.0.14
 configargparse==0.10.0


### PR DESCRIPTION
The API for CCCL changed to differentiate between 'net' and 'ltm'
resources. Update marathon-bigip-ctlr to use the new interface.