### PR TITLE
Add label back to docker build command.

### DIFF
--- a/build-tools/build-runtime-images.sh
+++ b/build-tools/build-runtime-images.sh
@@ -26,6 +26,7 @@ ls -la $WKDIR
 VERSION_BUILD_ARGS=$(${CURDIR}/version-tool docker-build-args)
 docker build --force-rm ${NO_CACHE_ARGS} \
   -t $IMG_TAG \
+  --label BUILD_STAMP=$BUILD_STAMP
   ${VERSION_BUILD_ARGS} \
   -f $WKDIR/Dockerfile.runtime \
   $WKDIR


### PR DESCRIPTION
Problem:
 The deletion of the --label argument is causing errors in the Jenkins
 build. The problem is that the controller tag is not being set which
 causes the $(systest_pkg) to be invalid. That variable is set in the
 Makefile and is used as an argument to run_systests.sh.

Solution:
 Add --label back into the docker build to make sure the tag is set.