### PR TITLE
Issue 246: Docker build image tag is not get set correctly

### DIFF
--- a/build-tools/build-runtime-images.sh
+++ b/build-tools/build-runtime-images.sh
@@ -26,6 +26,7 @@ ls -la $WKDIR
 VERSION_BUILD_ARGS=$(${CURDIR}/version-tool docker-build-args)
 docker build --force-rm ${NO_CACHE_ARGS} \
   -t $IMG_TAG \
+  --label BUILD_STAMP=$BUILD_STAMP \
   ${VERSION_BUILD_ARGS} \
   -f $WKDIR/Dockerfile.runtime \
   $WKDIR


### PR DESCRIPTION
The BUILD_STAMP was removed in commit eeae167, adding it back