### PR TITLE
CI build fails with pylint 1.8.1

### DIFF
--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -591,7 +591,7 @@ def get_apps(apps, health_check):
                      marathon_app.app['labels'])
 
         if len(service_ports) == 0:
-            logger.warning("Warning, no service ports found for " + appId)
+            logger.warning("Warning, no service ports found for %s", appId)
 
         for i, servicePort in enumerate(service_ports):
             try:
@@ -628,7 +628,7 @@ def get_apps(apps, health_check):
         for task in app['tasks']:
             # Marathon 0.7.6 bug workaround
             if len(task['host']) == 0:
-                logger.warning("Ignoring Marathon task without host " +
+                logger.warning("Ignoring Marathon task without host %s",
                                task['id'])
                 continue
 

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -6,5 +6,5 @@ flake8==3.2.1
 #flake8_docstrings==1.0.2
 mock
 coverage
-pylint
+pylint==1.8.1
 coveralls==1.1


### PR DESCRIPTION
CI build fails with newly-released (12/15/2017) pylint 1.8.1.
Resolved new issues discovered by pylint and pinned version.