### PR TITLE
Fix profile fields to avoid updates

### DIFF
--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -841,10 +841,16 @@ def create_config_marathon(cccl, apps):
                 # BIG-IP will automatically add the tcp profile for http
                 # because it is an inherited profile. Explictly add the tcp
                 # profile so that we don't fail comparison matches later.
-                profiles.append({'partition': 'Common', 'name': 'http'})
-                profiles.append({'partition': 'Common', 'name': 'tcp'})
+                profiles.append({'partition': 'Common',
+                                 'name': 'http',
+                                 'context': 'all'})
+                profiles.append({'partition': 'Common',
+                                 'name': 'tcp',
+                                 'context': 'all'})
             elif get_protocol(app.mode) == 'tcp':
-                profiles.append({'partition': 'Common', 'name': 'tcp'})
+                profiles.append({'partition': 'Common',
+                                 'name': 'tcp',
+                                 'context': 'all'})
 
             if app.bindAddr:
                 virtual = {

--- a/tests/marathon_app_no_hm_expected.json
+++ b/tests/marathon_app_no_hm_expected.json
@@ -101,11 +101,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {
@@ -122,11 +124,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_app_with_one_unconfig_service_port_expected.json
+++ b/tests/marathon_app_with_one_unconfig_service_port_expected.json
@@ -142,11 +142,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {
@@ -163,11 +165,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_one_app_https_expected.json
+++ b/tests/marathon_one_app_https_expected.json
@@ -80,11 +80,13 @@
                 },
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_one_app_in_subdir_expected.json
+++ b/tests/marathon_one_app_in_subdir_expected.json
@@ -76,11 +76,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_one_app_missing_data_expected.json
+++ b/tests/marathon_one_app_missing_data_expected.json
@@ -49,11 +49,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_one_app_no_port_label_expected.json
+++ b/tests/marathon_one_app_no_port_label_expected.json
@@ -76,11 +76,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_one_app_two_health_checks_expected.json
+++ b/tests/marathon_one_app_two_health_checks_expected.json
@@ -97,11 +97,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {
@@ -118,11 +120,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_one_app_two_service_ports_expected.json
+++ b/tests/marathon_one_app_two_service_ports_expected.json
@@ -118,11 +118,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {
@@ -139,11 +141,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_one_app_zero_instances_expected.json
+++ b/tests/marathon_one_app_zero_instances_expected.json
@@ -39,11 +39,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_two_apps_expected.json
+++ b/tests/marathon_two_apps_expected.json
@@ -117,11 +117,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {
@@ -138,11 +140,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {

--- a/tests/marathon_two_apps_v152_expected.json
+++ b/tests/marathon_two_apps_v152_expected.json
@@ -101,11 +101,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {
@@ -122,11 +124,13 @@
             "profiles": [
                 {
                     "name": "http",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 },
                 {
                     "name": "tcp",
-                    "partition": "Common"
+                    "partition": "Common",
+                    "context": "all"
                 }
             ],
             "sourceAddressTranslation": {


### PR DESCRIPTION
Problem: Profiles were missing the 'context' field, which caused unnecessary
updates to virtual servers every refresh cycle.

Solution: Include the 'context' fields in the profiles. This fixes the immediate issue,
but there is also a issue open in CCCL to adjust virtual comparisons in general to avoid
comparing defaults. This fix simply keeps fields consistent across all of our controllers.