### PR TITLE
Release Notes for CCCL Virtual Server bug fix

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,7 +1,7 @@
 Release Notes for F5 BIG-IP Controller for Marathon
 ===================================================
 
-|release|
+v1.2.0
 ----------
 
 Added Functionality
@@ -13,6 +13,7 @@ Added Functionality
 Bug Fixes
 `````````
 * Adds correct Marathon healthCheck path to BIG-IP Health Monitor Send String :issues:`256`
+* Corrected a comparison problem in CCCL that caused unnecessary updates for BIG-IP Virtual Server resources :cccl_issue:`198`
 
 Limitations
 ```````````

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,8 @@ with open('../next-version.txt') as verfile:
 # External links
 # Lets you reference GitHub issues in release notes, e.g. :issues:`214`
 extlinks = {'issues': ('https://github.com/F5Networks/marathon-bigip-ctlr/issues/%s',
+                      'issue '),
+                      'cccl-issue': ('https://github.com/f5devcentral/f5-cccl/issues/%s',
                       'issue ')}
 
 # Substitutions


### PR DESCRIPTION
Added a bug fix note for a comparison problem in CCCL that caused
unnecessary updates to occur for Virtual Servers on BIG-IP