### PR TITLE
Fix version information in documentation

### DIFF
--- a/build-tools/docker-docs.sh
+++ b/build-tools/docker-docs.sh
@@ -4,8 +4,27 @@ set -x
 
 : ${DOC_IMG:=f5devcentral/containthedocs:latest}
 
-exec docker run --rm -it \
-  -v $PWD:$PWD --workdir $PWD \
-  ${DOCKER_RUN_ARGS} \
-  -e "LOCAL_USER_ID=$(id -u)" \
-  ${DOC_IMG} "$@"
+RUN_ARGS=( \
+  --rm
+  -v $PWD:$PWD
+  --workdir $PWD
+  ${DOCKER_RUN_ARGS}
+  -e "LOCAL_USER_ID=$(id -u)"
+  -e TRAVIS=$TRAVIS
+)
+
+if [[ $TRAVIS_BRANCH == *"-stable" ]]; then
+  release="$(git describe --tags --abbrev=0)"
+  RUN_ARGS+=( -e DOCS_RELEASE=$release )
+  va=( ${release//./ } ) # replace decimals and split into array
+  version="${va[0]}.${va[1]}"
+  RUN_ARGS+=( -e DOCS_VERSION=$version )
+fi
+
+# Add -it if caller is a terminal
+if [ -t 0 ]; then
+  RUN_ARGS+=( "-it" )
+fi
+
+# Run the user provided args
+docker run "${RUN_ARGS[@]}" ${DOC_IMG} "$@"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,13 @@ BUILDDIR      = _build
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   =
+ifdef DOCS_RELEASE
+  ifdef DOCS_VERSION
+    ALLSPHINXOPTS += -D release=$(DOCS_RELEASE) -D version=$(DOCS_VERSION)
+  endif
+endif
+ALLSPHINXOPTS   += -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 


### PR DESCRIPTION
Problem:
The docs version string as displayed on the clouddocs sidebar for
product docs shows an incorrect version string.

Solution:
The problem is that the docs version string is based on the version
information from next-version.txt. This is okay for non-release branches
such as master but not accurate for the stable branches off of which we
pull releases.

The fix is to use the latest git tag to determine docs version for
stable branches.