### PR TITLE
Add python cryptography module to runtime image

### DIFF
--- a/build-tools/Dockerfile.runtime
+++ b/build-tools/Dockerfile.runtime
@@ -14,9 +14,15 @@ COPY common.py $APPPATH
 COPY marathon-bigip-ctlr.py $APPPATH
 COPY VERSION_BUILD.json $APPPATH
     
-RUN apk --no-cache --update add --virtual pip-install-deps git && \
-    pip install -r /tmp/runtime-requirements.txt && \
-    apk del pip-install-deps
+RUN apk --no-cache --update add libffi
+RUN apk --no-cache --update add --virtual pip-install-deps \
+    git \
+    gcc \
+    python-dev \
+    musl-dev \
+    libffi-dev \
+    openssl-dev && \
+  pip install -r /tmp/runtime-requirements.txt && apk del pip-install-deps
 
 USER ctlr
 

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,8 @@
 -e git+https://github.com/f5devcentral/f5-cccl.git@03e22c4779ceb88f529337ade3ca31ddcd57e4c8#egg=f5-cccl
+cryptography==1.3.2
+idna==2.2
+pyasn1==0.2.2
+pycparser==2.17
 requests==2.9.1
 sseclient==0.0.14
 configargparse==0.10.0


### PR DESCRIPTION
Problem:
The runtime image is missing the python cryptography module (and
its dependencies) required by py-jwt.

Solution:
Added the cryptography module and dependencies to marathon-runtime-requirements.txt and
added its build dependencies to build-tools/Dockerfile.runtime