### PR TITLE
Update docs version on version-tag commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ deploy:
     on:
       all_branches: true
       repo: F5Networks/marathon-bigip-ctlr
-      condition: $TRAVIS_BRANCH == *"-stable"
+      condition: $TRAVIS_BRANCH == *"-stable" || "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]*
     script:
       - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/marathon-bigip-ctlr v$CTLR_VERSION
 

--- a/build-tools/docker-docs.sh
+++ b/build-tools/docker-docs.sh
@@ -13,7 +13,7 @@ RUN_ARGS=( \
   -e TRAVIS=$TRAVIS
 )
 
-if [[ $TRAVIS_BRANCH == *"-stable" ]]; then
+if [[ $TRAVIS_BRANCH == *"-stable" || "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]* ]]; then
   release="$(git describe --tags --abbrev=0)"
   RUN_ARGS+=( -e DOCS_RELEASE=$release )
   va=( ${release//./ } ) # replace decimals and split into array


### PR DESCRIPTION
Problem:
Docs version string not being updated when a new version
tag is pushed. Also, docs are not published when new version
tags are pushed

Solution:
1. Changed the criteria for updating docs version string to include
version-tag expected string.
2. Changed condition in travis which allows docs publish
when new version tags are pushed.

Testing:

Ran the following commands to see docs version string is set:
TRAVIS=true TRAVIS_BRANCH="1.2-stable" ./build-tools/docker-docs.sh
TRAVIS=true TRAVIS_BRANCH="v1.2.1-beta.1" ./build-tools/docker-docs.sh
TRAVIS=true TRAVIS_BRANCH="v1.2.1" ./build-tools/docker-docs.sh

Ran the following commands to see docs version string is *not* set:
TRAVIS=true TRAVIS_BRANCH="master" ./build-tools/docker-docs.sh
TRAVIS=true TRAVIS_BRANCH="v1.1-beta.1" ./build-tools/docker-docs.sh