### PR TITLE
Update CCCL pointer to a version that contains a stable f5-icontrol-rest

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,13 @@
 Release Notes for F5 BIG-IP Controller for Marathon
 ===================================================
 
+v1.2.2
+------
+
+Bug Fixes
+`````````
+* :cccl-issue: Memory leak in f5-cccl submodule.
+
 v1.2.1
 ------
 

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@d55c2d24b03a50ecd71803501ea2db1dfed5efb5#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@d55c2d24b03a50ecd71803501ea2db1dfed5efb5#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
 cryptography==1.3.2
 idna==2.2
 pyasn1==0.2.2


### PR DESCRIPTION
Problem: The CCCL library currently pulls in the f5-icontrol-rest
via the f5-common-python package.  This package does not pin the
f5-icontrol-rest package and new builds will therefore pull the
latest version.

Solution: Updated CCCL to pin the f5-icontrol-rest to a previous
version that did not have a memory leak issue.