### PR TITLE
Replace specific next version in release notes with generic string

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,12 +1,12 @@
 Release Notes for F5 BIG-IP Controller for Marathon
 ===================================================
 
-v1.2.2
-------
+next-release
+------------
 
 Bug Fixes
 `````````
-* :cccl-issue: Memory leak in f5-cccl submodule.
+* :cccl-issue:`211` - Memory leak in f5-cccl submodule.
 
 v1.2.1
 ------


### PR DESCRIPTION
Problem:
Bugfixes destined for the next released version are being listed
under a specific version tag based off of the next-version in
the stable branch. There are some problems with this approach:
1. What if we don't cut that specific version as the next release?
2. When cherry-picking this change into the stable branch, we now
have release notes for the specific version published to clouddocs
which may confuse customers causing them to think they are behind.

Solution:
Any bugfixes for upcoming release are listed under a 'next-release'
section in the release notes (both in master and stable). The
workflow then would be to rename 'next-version' appropriately when
its time to cut a release (and cherry-pick that to the appropriate
stable branch).
Note: This commit also fixes some formatting issues with current
contents of bugfix section.