### PR TITLE
Added source address translation configuration.

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -41,9 +41,9 @@ The |mctlr-long| is a Docker container that runs as a `Marathon Application`_. I
 - creates health monitors on the BIG-IP for pool members if the Marathon App has health checks configured.
 
 .. danger::
- 
+
    The |mctlr-long| monitors the BIG-IP partition it manages for configuration changes. If it discovers changes, the Controller reapplies its own configuration to the BIG-IP system.
-   
+
    F5 does not recommend making configuration changes to objects in any partition managed by the |mctlr-long| via any other means (for example, the configuration utility, TMOS, or by syncing configuration with another device or service group). Doing so may result in disruption of service or unexpected behavior.
 
 .. _config parameters:
@@ -119,53 +119,66 @@ Application Labels for Normal Mode
 ``````````````````````````````````
 Use the following application labels to deploy virtual servers on the BIG-IP.
 
-+-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------------+
-| Parameter             | Type      | Required  | Default       | Description                               | Allowed Values                          |
-+=======================+===========+===========+===============+===========================================+=========================================+
-| F5_PARTITION          | string    | Required  | n/a           | BIG-IP partition in which to create       |                                         |
-|                       |           |           |               | objects; cannot be "Common"               |                                         |
-+-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------------+
-| \F5_{n}_BIND_ADDR     | string    | Optional  | n/a           | IP address of the App service [#ba]_      |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | Example:                                  |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | ``"F5_0_BIND_ADDR": "10.0.0.42"``         |                                         |
-+-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------------+
-| \F5_{n}_PORT          | string    | Required  | n/a           | Service port to use for communications    |                                         |
-|                       |           |           |               | with the BIG-IP                           |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | Overrides the ``servicePort``             |                                         |
-|                       |           |           |               | configuration parameter.                  |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | Example: ``"F5_0_PORT": "80"``            |                                         |
-+-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------------+
-| \F5_{n}_MODE          | string    | Optional  | tcp           | Connection mode                           | http, tcp                               |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | Example: ``"F5_0_MODE": "http"``          |                                         |
-+-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------------+
-| \F5_{n}_BALANCE       | string    | Optional  | round-robin   | Load-balancing algorithm [#lb]_           | See supported                           |
-|                       |           |           |               |                                           | `loadBalancingMode options in f5-cccl`_ |
-|                       |           |           |               | Example:                                  |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | ``"F5_0_BALANCE":``                       |                                         |
-|                       |           |           |               | ``"least-connections-member"``            |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               |                                           |                                         |
-+-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------------+
-| \F5_{n}_SSL_PROFILE   | string    | Optional  | n/a           | BIG-IP SSL profile to apply to an         | Any BIG-IP client SSL profile           |
-|                       |           |           |               | HTTPS virtual server                      |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | Example:                                  |                                         |
-|                       |           |           |               |                                           |                                         |
-|                       |           |           |               | ``"F5_0_SSL_PROFILE": "Common/clientssl"``|                                         |
-|                       |           |           |               |                                           |                                         |
-+-----------------------+-----------+-----------+---------------+-------------------------------------------+-----------------------------------------+
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
+| Parameter                       | Type      | Required  | Default       | Description                                                            | Allowed Values                          |
++=================================+===========+===========+===============+========================================================================+=========================================+
+| F5_PARTITION                    | string    | Required  | n/a           | BIG-IP partition in which to create                                    |                                         |
+|                                 |           |           |               | objects; cannot be "Common"                                            |                                         |
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
+| \F5_{n}_BIND_ADDR               | string    | Optional  | n/a           | IP address of the App service [#ba]_                                   |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | Example:                                                               |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | ``"F5_0_BIND_ADDR": "10.0.0.42"``                                      |                                         |
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
+| \F5_{n}_PORT                    | string    | Required  | n/a           | Service port to use for communications                                 |                                         |
+|                                 |           |           |               | with the BIG-IP                                                        |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | Overrides the ``servicePort``                                          |                                         |
+|                                 |           |           |               | configuration parameter.                                               |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | Example: ``"F5_0_PORT": "80"``                                         |                                         |
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
+| \F5_{n}_MODE                    | string    | Optional  | tcp           | Connection mode                                                        | http, tcp                               |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | Example: ``"F5_0_MODE": "http"``                                       |                                         |
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
+| \F5_{n}_BALANCE                 | string    | Optional  | round-robin   | Load-balancing algorithm [#lb]_                                        | See supported                           |
+|                                 |           |           |               |                                                                        | `loadBalancingMode options in f5-cccl`_ |
+|                                 |           |           |               | Example:                                                               |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | ``"F5_0_BALANCE":``                                                    |                                         |
+|                                 |           |           |               | ``"least-connections-member"``                                         |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               |                                                                        |                                         |
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
+| \F5_{n}_SSL_PROFILE             | string    | Optional  | n/a           | BIG-IP SSL profile to apply to an                                      | Any BIG-IP client SSL profile           |
+|                                 |           |           |               | HTTPS virtual server                                                   |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | Example:                                                               |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | ``"F5_0_SSL_PROFILE": "Common/clientssl"``                             |                                         |
+|                                 |           |           |               |                                                                        |                                         |
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
+| \F5_{n}_SOURCE_ADDR_TRANSLATION | string    | Optional  | automap       | JSON encoded string of a BIG-IP Source Address Translation type to     | automap, none, snat                     |
+|                                 |           |           |               | apply to a virtual server                                              |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | Example (automap or none):                                             |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | `"F5_0_SOURCE_ADDR_TRANSLATION": "{"type":"automap"}"`                 |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | Example (snat):                                                        |                                         |
+|                                 |           |           |               |                                                                        |                                         |
+|                                 |           |           |               | `"F5_0_SOURCE_ADDR_TRANSLATION": "{"type":"snat","pool":"snat-pool"}"` |                                         |
++---------------------------------+-----------+-----------+---------------+------------------------------------------------------------------------+-----------------------------------------+
 
 .. note::
 
    If you don't define ``F5_{n}_BIND_ADDR``, the Controller will create BIG-IP `pools without virtual servers`_. In such cases, **you should already have a BIG-IP virtual server** that handles client connections configured with an iRule or local traffic policy that can forward the request to the correct pool.
 
    You can `use an IPAM system`_ to populate the ``F5_{n}_BIND_ADDR`` label. When the Controller discovers a valid ``F5_{n}_BIND_ADDR`` for an Application, it creates a BIG-IP virtual server for the App with the specified the IP address.
+
+   See `Source Address Translation Overview`_ on AskF5 for more information on configuring virtual server source address translation.
 
 .. _app labels iapp:
 

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,16 @@ next-release
 Bug Fixes
 `````````
 
+v1.3.0
+------
+
+Added Functionality
+```````````````````
+* Support for virtual server source address translation configuration.
+
+Bug Fixes
+`````````
+
 v1.2.2
 ------
 

--- a/docs/_static/config_examples/sample-marathon-application.json
+++ b/docs/_static/config_examples/sample-marathon-application.json
@@ -27,9 +27,11 @@
     "F5_0_BIND_ADDR": "10.128.10.240",
     "F5_0_MODE": "http",
     "F5_0_PORT": "8080",
+    "F5_0_SOURCE_ADDR_TRANSLATION": "{\"type\":\"none\"}",
     "F5_1_BIND_ADDR": "10.128.10.242",
     "F5_1_MODE": "http",
-    "F5_1_PORT": "8090"
+    "F5_1_PORT": "8090",
+    "F5_1_SOURCE_ADDR_TRANSLATION": "{\"type\":\"snat\",\"pool\":\"snat-pool\"}"
   },
   "healthChecks": [
     {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,7 @@ rst_epilog = '''
 .. _port-mapping: https://mesosphere.github.io/marathon/docs/ports.html
 .. _iApps: https://devcentral.f5.com/iapps
 .. _route domain: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/9.html
+.. _Source Address Translation Overview: https://support.f5.com/csp/article/K7820
 ''' % {
     'url_version': version,
     'base_url': 'http://clouddocs.f5.com'

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@2ec3832fb874e02956930f75567424f09f6dad35#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@2ec3832fb874e02956930f75567424f09f6dad35#egg=f5-cccl
 cryptography==1.3.2
 idna==2.2
 pyasn1==0.2.2


### PR DESCRIPTION
Problem:
 Current controller does not allow configuration of virtual server
 source address translation on a per vs basis.

Solution:
 Add configurable source address translation fields for virtual servers
 based on app labels that default to automap if the label is not set.