### PR TITLE
Metadata for BIG-IP LTM resources

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,10 @@ Release Notes for F5 BIG-IP Controller for Marathon
 next-release
 ------------
 
+Added Functionality
+```````````````````
+* Added controller name and version to the metadata of certain BIG-IP LTM resources managed by the controller.
+
 Bug Fixes
 `````````
 

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@a2bc189d18c05b4ee611671e3138255fdc7a9b44#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@a2bc189d18c05b4ee611671e3138255fdc7a9b44#egg=f5-cccl
 cryptography==1.3.2
 idna==2.2
 pyasn1==0.2.2


### PR DESCRIPTION
Added controller name and version to the metadata of certain
BIG-IP LTM resources managed by the controller.