### PR TITLE
Support Mesos-level health checks

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,6 +10,7 @@ Added Functionality
 
 Bug Fixes
 `````````
+* :issues:`314` - Support new health-check protocols (MESOS_HTTP, MESOS_HTTPS, and MESOS_TCP) introduced in DC/OS 1.10.
 
 v1.3.0
 ------

--- a/marathon-bigip-ctlr.py
+++ b/marathon-bigip-ctlr.py
@@ -793,6 +793,10 @@ def create_config_marathon(cccl, apps, snat_pool_name):
                     # normalize healthcheck protocol name to lowercase
                     if 'protocol' in hc:
                         hc['type'] = (hc['protocol']).lower()
+                        if 'http' in hc['type']:
+                            hc['type'] = 'http'
+                        if 'tcp' in hc['type']:
+                            hc['type'] = 'tcp'
                     hc.update({
                         'interval': hc['intervalSeconds'],
                         'timeout': healthcheck_timeout_calculate(hc)

--- a/tests/marathon_one_app_two_health_checks.json
+++ b/tests/marathon_one_app_two_health_checks.json
@@ -117,7 +117,7 @@
         "healthChecks": [
             {
                 "path": "/this/is/a/nondefault/path",
-                "protocol": "HTTP",
+                "protocol": "MESOS_HTTP",
                 "portIndex": 0,
                 "gracePeriodSeconds": 300,
                 "intervalSeconds": 60,
@@ -127,7 +127,7 @@
             },
             {
                 "path": "/",
-                "protocol": "TCP",
+                "protocol": "MESOS_TCP",
                 "portIndex": 0,
                 "gracePeriodSeconds": 300,
                 "intervalSeconds": 60,

--- a/tests/marathon_one_app_two_health_checks_expected.json
+++ b/tests/marathon_one_app_two_health_checks_expected.json
@@ -11,7 +11,7 @@
             "name": "server-app_80_0_http",
             "path": "/this/is/a/nondefault/path",
             "portIndex": 0,
-            "protocol": "HTTP",
+            "protocol": "MESOS_HTTP",
             "send": "GET /this/is/a/nondefault/path HTTP/1.0\\r\\n\\r\\n",
             "timeout": 141,
             "timeoutSeconds": 20,
@@ -26,7 +26,7 @@
             "name": "server-app_80_1_tcp",
             "path": "/",
             "portIndex": 0,
-            "protocol": "TCP",
+            "protocol": "MESOS_TCP",
             "timeout": 141,
             "timeoutSeconds": 20,
             "type": "tcp"


### PR DESCRIPTION
DC/OS 1.10 added the concept of Mesos-level health checks. Create
BIG-IP health monitors for these just as we do for the Marathon-level
health checks.

Fixes #314