### PR TITLE
Update CCCL pointer for metadata bug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,7 +117,7 @@ rst_epilog = '''
 .. |mctlr| replace:: :code:`marathon-bigip-ctlr`
 .. |mctlr-long| replace:: F5 BIG-IP Controller for Marathon
 .. _user documentation: %(base_url)s/containers/latest/marathon/
-.. _pools without virtual servers: %(base_url)s/containers/latest/marathon/mctlr-manage-bigip-objects.html#manage-pools-without-virtual-servers
+.. _pools without virtual servers: %(base_url)s/containers/latest/marathon/mctlr-manage-bigip-objects.html#pools-without-virtual-servers
 .. _use an IPAM system: %(base_url)s/containers/latest/marathon/mctlr-manage-bigip-objects.html#use-ipam-to-assign-ip-addresses-to-big-ip-virtual-servers
 .. _Enterprise DC/OS: https://mesosphere.com/product/
 .. _Identity and Access Management API: https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/oss/iam-api/

--- a/marathon-build-requirements.txt
+++ b/marathon-build-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.2
--e git+https://github.com/f5devcentral/f5-cccl.git@8a3663ba4d401eed6ba428a14b4b629b983c772f#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@39835ebf3d7cf38c6ce2fbec883be7b18b6ba5ff#egg=f5-cccl
 cryptography==1.3.2
 flake8==3.2.1
 # Cannot use flake8_docstrings until https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed.

--- a/marathon-runtime-requirements.txt
+++ b/marathon-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@8a3663ba4d401eed6ba428a14b4b629b983c772f#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@39835ebf3d7cf38c6ce2fbec883be7b18b6ba5ff#egg=f5-cccl
 cryptography==1.3.2
 idna==2.2
 pyasn1==0.2.2


### PR DESCRIPTION
CCCL incorrectly tried to get the length of a Nonetype. Metadata is a new addition to this version, so if upgrading controller versions, CCCL would hit this nonetype and throw an exception. CCCL now properly compares empty lists rather than Nonetypes.